### PR TITLE
[SQC-100] feat: 카테고리 선택 ui 구현

### DIFF
--- a/app/src/main/java/com/android/quizcafe/core/designsystem/Button.kt
+++ b/app/src/main/java/com/android/quizcafe/core/designsystem/Button.kt
@@ -20,12 +20,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.android.quizcafe.core.designsystem.theme.QuizCafeTheme
 import com.android.quizcafe.core.designsystem.theme.primaryLight
+import com.android.quizcafe.core.designsystem.theme.scrimLight
 import com.android.quizcafe.core.designsystem.theme.surfaceDimLight
 
 /**
@@ -48,7 +48,7 @@ fun QuizCafeButton(
     shape: Shape = RoundedCornerShape(8.dp),
     colors: ButtonColors = ButtonDefaults.buttonColors(
         containerColor = primaryLight,
-        contentColor = Color.Black,
+        contentColor = scrimLight,
         disabledContainerColor = surfaceDimLight
     ),
     contentPadding: PaddingValues = if (leadingIcon != null) {

--- a/app/src/main/java/com/android/quizcafe/core/designsystem/TextField.kt
+++ b/app/src/main/java/com/android/quizcafe/core/designsystem/TextField.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -20,12 +22,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.android.quizcafe.core.designsystem.theme.errorLight
+import com.android.quizcafe.core.designsystem.theme.onSurfaceVariantLight
 import com.android.quizcafe.core.designsystem.theme.primaryContainerLight
 import com.android.quizcafe.core.designsystem.theme.primaryLight
 import com.android.quizcafe.core.designsystem.theme.quizCafeTypography
+import com.android.quizcafe.core.designsystem.theme.scrimLight
 import com.android.quizcafe.core.designsystem.theme.surfaceBrightLight
 
 @Composable
@@ -52,7 +57,7 @@ fun QuizCafeTextField(
             modifier = if (errorMessage != null) {
                 modifier.border(
                     1.dp,
-                    Color.Red,
+                    errorLight,
                     RoundedCornerShape(10.dp)
                 )
             } else {
@@ -60,8 +65,8 @@ fun QuizCafeTextField(
             },
             enabled = enabled,
             colors = TextFieldDefaults.colors(
-                focusedTextColor = Color.Black,
-                unfocusedTextColor = Color.DarkGray,
+                focusedTextColor = scrimLight,
+                unfocusedTextColor = onSurfaceVariantLight,
                 disabledContainerColor = surfaceBrightLight,
                 focusedContainerColor = primaryContainerLight,
                 unfocusedContainerColor = primaryContainerLight,
@@ -113,3 +118,5 @@ fun LabeledInputField(
         enabled = enabled
     )
 }
+
+@Preview(showBackground = true)

--- a/app/src/main/java/com/android/quizcafe/core/designsystem/TextField.kt
+++ b/app/src/main/java/com/android/quizcafe/core/designsystem/TextField.kt
@@ -120,3 +120,19 @@ fun LabeledInputField(
 }
 
 @Preview(showBackground = true)
+@Composable
+fun LabeledInputFieldPreview() {
+    Column {
+        LabeledInputField(
+            label = "label",
+            value = "text",
+            onValueChange = {}
+        )
+        LabeledInputField(
+            label = "label",
+            value = "text",
+            onValueChange = {},
+            errorMessage = "error"
+        )
+    }
+}

--- a/app/src/main/java/com/android/quizcafe/core/designsystem/theme/Type.kt
+++ b/app/src/main/java/com/android/quizcafe/core/designsystem/theme/Type.kt
@@ -34,7 +34,14 @@ fun quizCafeTypography(): Typography {
         titleLarge = TextStyle(
             fontFamily = fontFamily,
             fontWeight = FontWeight.Normal,
-            fontSize = 22.sp,
+            fontSize = 28.sp,
+            lineHeight = 28.sp,
+            letterSpacing = 0.sp
+        ),
+        titleMedium = TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = FontWeight.Normal,
+            fontSize = 20.sp,
             lineHeight = 28.sp,
             letterSpacing = 0.sp
         ),

--- a/app/src/main/java/com/android/quizcafe/core/ui/Title.kt
+++ b/app/src/main/java/com/android/quizcafe/core/ui/Title.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -19,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.android.quizcafe.core.designsystem.theme.outlineVariantLight
+import com.android.quizcafe.core.designsystem.theme.quizCafeTypography
 
 @Composable
 fun AnimatedTitleWithBody(
@@ -45,4 +48,16 @@ fun AnimatedTitleWithBody(
         content()
         Spacer(modifier = Modifier.height(40.dp))
     }
+}
+
+// TopAppBar를 사용하지 않는 underline Title
+@Composable
+fun TitleWithUnderLine(title: String) {
+    Spacer(Modifier.height(60.dp))
+    Text(
+        text = title,
+        style = quizCafeTypography().titleLarge
+    )
+    Spacer(Modifier.height(16.dp))
+    HorizontalDivider(thickness = 1.dp, color = outlineVariantLight)
 }

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/Category.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/Category.kt
@@ -1,0 +1,7 @@
+package com.android.quizcafe.feature.categorypicker
+
+// 임시 데이터 클래스
+data class Category(
+    val group: String,
+    val name: String
+)

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
@@ -1,0 +1,93 @@
+package com.android.quizcafe.feature.categorypicker
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.android.quizcafe.R
+import com.android.quizcafe.core.designsystem.theme.QuizCafeTheme
+import com.android.quizcafe.core.designsystem.theme.quizCafeTypography
+
+@Composable
+fun CategoryCardList(categories: List<Category>) {
+    LazyColumn {
+        items(categories) { category ->
+            CategoryCard(category = category)
+        }
+    }
+}
+
+@Composable
+fun CategoryCard(category: Category) {
+    Spacer(Modifier.height(8.dp))
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        onClick = {
+            // TODO: 문제집 화면으로 이동
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = category.group,
+                color = Color.Gray,
+                style = quizCafeTypography().bodyLarge
+            )
+            Spacer(Modifier.height(8.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = category.name,
+                    style = quizCafeTypography().titleMedium
+                )
+
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = stringResource(R.string.go),
+                    tint = Color.Black,
+                    modifier = Modifier.height(24.dp)
+                )
+            }
+        }
+    }
+    Spacer(Modifier.height(8.dp))
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CategoryCardPreview() {
+    QuizCafeTheme {
+        CategoryCardList(listOf(Category("그룹", "카테고리 이름"), Category("그룹", "카테고리 이름")))
+    }
+}

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -20,13 +19,15 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.android.quizcafe.R
 import com.android.quizcafe.core.designsystem.theme.QuizCafeTheme
+import com.android.quizcafe.core.designsystem.theme.onPrimaryLight
+import com.android.quizcafe.core.designsystem.theme.outlineLight
 import com.android.quizcafe.core.designsystem.theme.quizCafeTypography
+import com.android.quizcafe.core.designsystem.theme.scrimLight
 
 @Composable
 fun CategoryCardList(categories: List<Category>) {
@@ -44,20 +45,18 @@ fun CategoryCard(category: Category) {
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(8.dp),
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
+        colors = CardDefaults.cardColors(containerColor = onPrimaryLight),
         onClick = {
             // TODO: 문제집 화면으로 이동
         }
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp),
+            modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
             Text(
                 text = category.group,
-                color = Color.Gray,
+                color = outlineLight,
                 style = quizCafeTypography().bodyLarge
             )
             Spacer(Modifier.height(8.dp))
@@ -75,7 +74,7 @@ fun CategoryCard(category: Category) {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                     contentDescription = stringResource(R.string.go),
-                    tint = Color.Black,
+                    tint = scrimLight,
                     modifier = Modifier.height(24.dp)
                 )
             }

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerScreen.kt
@@ -1,0 +1,49 @@
+package com.android.quizcafe.feature.categorypicker
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.android.quizcafe.R
+import com.android.quizcafe.core.designsystem.theme.QuizCafeTheme
+import com.android.quizcafe.core.ui.TitleWithUnderLine
+
+@Composable
+fun CategoryPickerScreen() {
+    // 임시 데이터
+    val categories = listOf(
+        Category("Computer Science", "네트워크"),
+        Category("Computer Science", "운영체제"),
+        Category("Computer Science", "알고리즘"),
+        Category("Android", "안드로이드"),
+        Category("Computer Science", "네트워크"),
+        Category("Computer Science", "운영체제"),
+        Category("Computer Science", "알고리즘"),
+        Category("Android", "안드로이드"),
+        Category("Programming Language", "코틀린")
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        TitleWithUnderLine(stringResource(R.string.pick_category))
+        Spacer(Modifier.height(12.dp))
+        CategoryCardList(categories)
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CategoryPickerScreenPreview() {
+    QuizCafeTheme {
+        CategoryPickerScreen()
+    }
+}

--- a/app/src/main/java/com/android/quizcafe/feature/login/LoginContent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/login/LoginContent.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
@@ -23,6 +22,7 @@ import com.android.quizcafe.R
 import com.android.quizcafe.core.designsystem.QuizCafeButton
 import com.android.quizcafe.core.designsystem.QuizCafeTextField
 import com.android.quizcafe.core.designsystem.theme.QuizCafeTheme
+import com.android.quizcafe.core.designsystem.theme.outlineLight
 
 @Composable
 fun QuizCafeLogo() {
@@ -83,7 +83,7 @@ fun BottomTextOptions(onIntent: (LoginIntent) -> Unit) {
         Text(
             text = stringResource(R.string.forgot_password),
             fontSize = 14.sp,
-            color = Color.Gray
+            color = outlineLight
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,5 +21,7 @@
     <string name="forgot_password">비밀번호를 잊어버리셨나요?</string>
     <string name="quizcafe_logo">QuizCafe Logo</string>
     <string name="resend">재전송</string>
+    <string name="pick_category">카테고리 선택</string>
+    <string name="go">Go</string>
 
 </resources>


### PR DESCRIPTION
## Description

- [x] 카테고리 선택 ui 구현
---
## Summary

카테고리 선택 ui를 구현했습니다.
titleLarge 폰트 스타일을 변경했습니다.
titleMedium 폰트 스타일을 추가했습니다.
구분선을 포함한 타이틀을 공통 컴포넌트에 추가했습니다


---
### ScreenShot

<img src="https://github.com/user-attachments/assets/96831f57-a9a4-4adf-8392-906db4d45280" width="300"/>


---

## Test
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 단위 테스트 또는 통합 테스트 또는 Preview를 추가했습니다.
- [ ] UI 테스트를 진행했습니다.
- [ ] CI 테스트까지 완료했습니다.

---


---
