### PR TITLE
[SQC-108] 카테고리 목록 API, Domain, ViewModel 로직 구현,  ApiResult to Resource 변환 로직 개선

### DIFF
--- a/app/src/androidTest/java/com/android/quizcafe/di/FakeServiceModule.kt
+++ b/app/src/androidTest/java/com/android/quizcafe/di/FakeServiceModule.kt
@@ -2,6 +2,7 @@ package com.android.quizcafe.di
 
 import com.android.quizcafe.core.data.di.ServiceModule
 import com.android.quizcafe.core.data.remote.service.AuthService
+import com.android.quizcafe.core.data.remote.service.QuizBookService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.components.SingletonComponent
@@ -21,5 +22,11 @@ object FakeServiceModule {
     @Singleton
     fun provideAuthService(@Named("default") retrofit: Retrofit): AuthService {
         return retrofit.create(AuthService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideQuizBookService(@Named("token") retrofit: Retrofit): QuizBookService {
+        return retrofit.create(QuizBookService::class.java)
     }
 }

--- a/app/src/main/java/com/android/quizcafe/core/data/di/DataModule.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/di/DataModule.kt
@@ -1,7 +1,9 @@
 package com.android.quizcafe.core.data.di
 
 import com.android.quizcafe.core.data.repository.AuthRepositoryImpl
+import com.android.quizcafe.core.data.repository.QuizBookRepositoryImpl
 import com.android.quizcafe.core.domain.repository.AuthRepository
+import com.android.quizcafe.core.domain.repository.QuizBookRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -17,4 +19,10 @@ internal interface DataModule {
     fun bindAuthRepository(
         authRepository: AuthRepositoryImpl
     ): AuthRepository
+
+    @Singleton
+    @Binds
+    fun bindQuizBookRepository(
+        quizBookRepository: QuizBookRepositoryImpl
+    ): QuizBookRepository
 }

--- a/app/src/main/java/com/android/quizcafe/core/data/di/ServiceModule.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/di/ServiceModule.kt
@@ -1,6 +1,7 @@
 package com.android.quizcafe.core.data.di
 
 import com.android.quizcafe.core.data.remote.service.AuthService
+import com.android.quizcafe.core.data.remote.service.QuizBookService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,4 +19,10 @@ object ServiceModule {
     fun provideAuthService(
         @Named("default") retrofit: Retrofit
     ): AuthService = retrofit.create(AuthService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideQuizBookService(
+        @Named("token") retrofit: Retrofit
+    ): QuizBookService = retrofit.create(QuizBookService::class.java)
 }

--- a/app/src/main/java/com/android/quizcafe/core/data/model/quizbook/request/CategoryRequestDto.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/model/quizbook/request/CategoryRequestDto.kt
@@ -1,0 +1,14 @@
+package com.android.quizcafe.core.data.model.quizbook.request
+
+import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CategoryRequestDto(
+    val quizType: String
+)
+
+fun CategoryRequest.toDto() =
+    CategoryRequestDto(
+        quizType = this.quizType
+    )

--- a/app/src/main/java/com/android/quizcafe/core/data/model/quizbook/response/CategoryResponseDto.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/model/quizbook/response/CategoryResponseDto.kt
@@ -1,0 +1,18 @@
+package com.android.quizcafe.core.data.model.quizbook.response
+
+import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CategoryResponseDto(
+    @SerialName("category") val categoryId: String,
+    @SerialName("name") val categoryName: String,
+    val group: String
+)
+
+fun CategoryResponseDto.toDomain() = Category(
+    id = categoryId,
+    name = categoryName,
+    group = group
+)

--- a/app/src/main/java/com/android/quizcafe/core/data/model/quizbook/response/CategoryResponseDto.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/model/quizbook/response/CategoryResponseDto.kt
@@ -1,6 +1,6 @@
 package com.android.quizcafe.core.data.model.quizbook.response
 
-import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.domain.model.quizbook.response.Category
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/app/src/main/java/com/android/quizcafe/core/data/remote/datasource/QuizBookRemoteDataSource.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/remote/datasource/QuizBookRemoteDataSource.kt
@@ -1,0 +1,16 @@
+package com.android.quizcafe.core.data.remote.datasource
+
+import com.android.quizcafe.core.data.model.quizbook.request.CategoryRequestDto
+import com.android.quizcafe.core.data.model.quizbook.response.CategoryResponseDto
+import com.android.quizcafe.core.data.remote.service.QuizBookService
+import com.android.quizcafe.core.network.model.ApiResponse
+import com.android.quizcafe.core.network.model.NetworkResult
+import javax.inject.Inject
+
+class QuizBookRemoteDataSource @Inject constructor(
+    private val quizBookService: QuizBookService
+) {
+    // TODO: 카테고리 요청 api 수정 시 request 추가하기
+    suspend fun getCategoriesByType(request: CategoryRequestDto): NetworkResult<ApiResponse<List<CategoryResponseDto>>> =
+        quizBookService.getCategories()
+}

--- a/app/src/main/java/com/android/quizcafe/core/data/remote/service/QuizBookService.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/remote/service/QuizBookService.kt
@@ -1,0 +1,15 @@
+package com.android.quizcafe.core.data.remote.service
+
+import com.android.quizcafe.core.data.model.quizbook.response.CategoryResponseDto
+import com.android.quizcafe.core.network.model.ApiResponse
+import com.android.quizcafe.core.network.model.NetworkResult
+import retrofit2.http.GET
+
+interface QuizBookService {
+
+    // TODO: 카테고리 요청 api 수정 시 request 추가하기
+    @GET("quiz-book/category")
+    suspend fun getCategories(
+//        @Body request: QuizBookRequest
+    ): NetworkResult<ApiResponse<List<CategoryResponseDto>>>
+}

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/AuthRepositoryImpl.kt
@@ -12,7 +12,7 @@ import com.android.quizcafe.core.domain.model.auth.request.SignUpRequest
 import com.android.quizcafe.core.domain.model.auth.request.VerifyCodeRequest
 import com.android.quizcafe.core.domain.repository.AuthRepository
 import com.android.quizcafe.core.network.mapper.DEFAULT_ERROR_MESSAGE
-import com.android.quizcafe.core.network.mapper.apiResponseToResourceFlow
+import com.android.quizcafe.core.network.mapper.apiNoResponseToResourceFlow
 import com.android.quizcafe.core.network.mapper.handleNetworkException
 import com.android.quizcafe.core.network.model.onError
 import com.android.quizcafe.core.network.model.onException
@@ -29,16 +29,16 @@ class AuthRepositoryImpl @Inject constructor(
     private val authManager: AuthManager
 ) : AuthRepository {
 
-    override suspend fun sendCode(request: SendCodeRequest): Flow<Resource<Unit>> =
-        apiResponseToResourceFlow { remoteDataSource.sendCode(request.toDto()) }
+    override fun sendCode(request: SendCodeRequest): Flow<Resource<Unit>> =
+        apiNoResponseToResourceFlow { remoteDataSource.sendCode(request.toDto()) }
 
-    override suspend fun verifyCode(request: VerifyCodeRequest): Flow<Resource<Unit>> =
-        apiResponseToResourceFlow { remoteDataSource.verifyCode(request.toDto()) }
+    override fun verifyCode(request: VerifyCodeRequest): Flow<Resource<Unit>> =
+        apiNoResponseToResourceFlow { remoteDataSource.verifyCode(request.toDto()) }
 
-    override suspend fun signUp(request: SignUpRequest): Flow<Resource<Unit>> =
-        apiResponseToResourceFlow { remoteDataSource.signUp(request.toDto()) }
+    override fun signUp(request: SignUpRequest): Flow<Resource<Unit>> =
+        apiNoResponseToResourceFlow { remoteDataSource.signUp(request.toDto()) }
 
-    override suspend fun login(request: LoginRequest): Flow<Resource<Unit>> = flow {
+    override fun login(request: LoginRequest): Flow<Resource<Unit>> = flow {
         emit(Resource.Loading)
         withTimeoutOrNull(3_000L) {
             remoteDataSource.login(request.toDto())
@@ -65,6 +65,6 @@ class AuthRepositoryImpl @Inject constructor(
         )
     }.flowOn(Dispatchers.IO)
 
-    override suspend fun resetPassword(request: ResetPasswordRequest): Flow<Resource<Unit>> =
-        apiResponseToResourceFlow { remoteDataSource.resetPassword(request.toDto()) }
+    override fun resetPassword(request: ResetPasswordRequest): Flow<Resource<Unit>> =
+        apiNoResponseToResourceFlow { remoteDataSource.resetPassword(request.toDto()) }
 }

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/AuthRepositoryImpl.kt
@@ -12,7 +12,7 @@ import com.android.quizcafe.core.domain.model.auth.request.SignUpRequest
 import com.android.quizcafe.core.domain.model.auth.request.VerifyCodeRequest
 import com.android.quizcafe.core.domain.repository.AuthRepository
 import com.android.quizcafe.core.network.mapper.DEFAULT_ERROR_MESSAGE
-import com.android.quizcafe.core.network.mapper.apiNoResponseToResourceFlow
+import com.android.quizcafe.core.network.mapper.emptyApiResponseToResourceFlow
 import com.android.quizcafe.core.network.mapper.handleNetworkException
 import com.android.quizcafe.core.network.model.onError
 import com.android.quizcafe.core.network.model.onException
@@ -30,13 +30,13 @@ class AuthRepositoryImpl @Inject constructor(
 ) : AuthRepository {
 
     override fun sendCode(request: SendCodeRequest): Flow<Resource<Unit>> =
-        apiNoResponseToResourceFlow { remoteDataSource.sendCode(request.toDto()) }
+        emptyApiResponseToResourceFlow { remoteDataSource.sendCode(request.toDto()) }
 
     override fun verifyCode(request: VerifyCodeRequest): Flow<Resource<Unit>> =
-        apiNoResponseToResourceFlow { remoteDataSource.verifyCode(request.toDto()) }
+        emptyApiResponseToResourceFlow { remoteDataSource.verifyCode(request.toDto()) }
 
     override fun signUp(request: SignUpRequest): Flow<Resource<Unit>> =
-        apiNoResponseToResourceFlow { remoteDataSource.signUp(request.toDto()) }
+        emptyApiResponseToResourceFlow { remoteDataSource.signUp(request.toDto()) }
 
     override fun login(request: LoginRequest): Flow<Resource<Unit>> = flow {
         emit(Resource.Loading)
@@ -66,5 +66,5 @@ class AuthRepositoryImpl @Inject constructor(
     }.flowOn(Dispatchers.IO)
 
     override fun resetPassword(request: ResetPasswordRequest): Flow<Resource<Unit>> =
-        apiNoResponseToResourceFlow { remoteDataSource.resetPassword(request.toDto()) }
+        emptyApiResponseToResourceFlow { remoteDataSource.resetPassword(request.toDto()) }
 }

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
@@ -5,9 +5,9 @@ import com.android.quizcafe.core.data.model.quizbook.response.toDomain
 import com.android.quizcafe.core.data.model.quizbook.request.toDto
 import com.android.quizcafe.core.data.remote.datasource.QuizBookRemoteDataSource
 import com.android.quizcafe.core.domain.model.Resource
-import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
-import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBook
-import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBookDetail
+import com.android.quizcafe.core.domain.model.quizbook.response.Category
+import com.android.quizcafe.core.domain.model.quizbook.response.QuizBook
+import com.android.quizcafe.core.domain.model.quizbook.response.QuizBookDetail
 import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
 import com.android.quizcafe.core.domain.repository.QuizBookRepository
 import com.android.quizcafe.core.network.mapper.apiResponseToResourceFlow

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
@@ -10,7 +10,7 @@ import com.android.quizcafe.core.domain.model.quizbook.response.QuizBook
 import com.android.quizcafe.core.domain.model.quizbook.response.QuizBookDetail
 import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
 import com.android.quizcafe.core.domain.repository.QuizBookRepository
-import com.android.quizcafe.core.network.mapper.apiResponseToResourceFlow
+import com.android.quizcafe.core.network.mapper.apiResponseListToResourceFlow
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -19,7 +19,7 @@ class QuizBookRepositoryImpl @Inject constructor(
 ) : QuizBookRepository {
 
     override fun getAllCategories(categoryRequest: CategoryRequest): Flow<Resource<List<Category>>> =
-        apiResponseToResourceFlow(mapper = CategoryResponseDto::toDomain) {
+        apiResponseListToResourceFlow(mapper = CategoryResponseDto::toDomain) {
             quizBookRemoteDataSource.getCategoriesByType(categoryRequest.toDto())
         }
 

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.android.quizcafe.core.data.repository
+
+import com.android.quizcafe.core.data.model.quizbook.response.CategoryResponseDto
+import com.android.quizcafe.core.data.model.quizbook.response.toDomain
+import com.android.quizcafe.core.data.model.quizbook.request.toDto
+import com.android.quizcafe.core.data.remote.datasource.QuizBookRemoteDataSource
+import com.android.quizcafe.core.domain.model.Resource
+import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBook
+import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBookDetail
+import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
+import com.android.quizcafe.core.domain.repository.QuizBookRepository
+import com.android.quizcafe.core.network.mapper.apiResponseToResourceFlow
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class QuizBookRepositoryImpl @Inject constructor(
+    private val quizBookRemoteDataSource: QuizBookRemoteDataSource
+) : QuizBookRepository {
+
+    override fun getAllCategories(categoryRequest: CategoryRequest): Flow<Resource<List<Category>>> =
+        apiResponseToResourceFlow(mapper = CategoryResponseDto::toDomain) {
+            quizBookRemoteDataSource.getCategoriesByType(categoryRequest.toDto())
+        }
+
+    override fun getQuizBooksByCategory(categoryId: String): Flow<Resource<List<QuizBook>>> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getQuizBookById(id: Long): Flow<Resource<QuizBookDetail>> {
+        TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/Resource.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/Resource.kt
@@ -4,7 +4,7 @@ sealed class Resource<out R> {
     data object Loading : Resource<Nothing>()
 
     data class Success<out T>(
-        val data: T?
+        val data: T
     ) : Resource<T>()
 
     data class Failure(

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/reponse/Category.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/reponse/Category.kt
@@ -1,0 +1,7 @@
+package com.android.quizcafe.core.domain.model.quizbook.reponse
+
+data class Category(
+    val id: String,
+    val group: String,
+    val name: String
+)

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/reponse/QuizBook.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/reponse/QuizBook.kt
@@ -1,0 +1,6 @@
+package com.android.quizcafe.core.domain.model.quizbook.reponse
+
+// TODO: API Response에 맞게 수정
+data class QuizBook(
+    val id: Long
+)

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/reponse/QuizBookDetail.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/reponse/QuizBookDetail.kt
@@ -1,0 +1,6 @@
+package com.android.quizcafe.core.domain.model.quizbook.reponse
+
+// TODO: API Response에 맞게 수정
+data class QuizBookDetail(
+    val id: Long
+)

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/request/CategoryRequest.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/request/CategoryRequest.kt
@@ -1,0 +1,5 @@
+package com.android.quizcafe.core.domain.model.quizbook.request
+
+data class CategoryRequest(
+    val quizType: String
+)

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/request/QuizBookDetailRequest.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/request/QuizBookDetailRequest.kt
@@ -1,0 +1,6 @@
+package com.android.quizcafe.core.domain.model.quizbook.request
+
+// TODO: API Response에 맞게 수정
+data class QuizBookDetailRequest(
+    val quizBookId: Long
+)

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/request/QuizBookRequest.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/request/QuizBookRequest.kt
@@ -1,0 +1,6 @@
+package com.android.quizcafe.core.domain.model.quizbook.request
+
+// TODO: API Response에 맞게 수정
+data class QuizBookRequest(
+    val categoryId: Long
+)

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/response/Category.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/response/Category.kt
@@ -1,4 +1,4 @@
-package com.android.quizcafe.core.domain.model.quizbook.reponse
+package com.android.quizcafe.core.domain.model.quizbook.response
 
 data class Category(
     val id: String,

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/response/QuizBook.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/response/QuizBook.kt
@@ -1,4 +1,4 @@
-package com.android.quizcafe.core.domain.model.quizbook.reponse
+package com.android.quizcafe.core.domain.model.quizbook.response
 
 // TODO: API Response에 맞게 수정
 data class QuizBook(

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/response/QuizBookDetail.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quizbook/response/QuizBookDetail.kt
@@ -1,4 +1,4 @@
-package com.android.quizcafe.core.domain.model.quizbook.reponse
+package com.android.quizcafe.core.domain.model.quizbook.response
 
 // TODO: API Response에 맞게 수정
 data class QuizBookDetail(

--- a/app/src/main/java/com/android/quizcafe/core/domain/repository/AuthRepository.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/repository/AuthRepository.kt
@@ -10,13 +10,13 @@ import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
 
-    suspend fun sendCode(request: SendCodeRequest): Flow<Resource<Unit>>
+    fun sendCode(request: SendCodeRequest): Flow<Resource<Unit>>
 
-    suspend fun verifyCode(request: VerifyCodeRequest): Flow<Resource<Unit>>
+    fun verifyCode(request: VerifyCodeRequest): Flow<Resource<Unit>>
 
-    suspend fun signUp(request: SignUpRequest): Flow<Resource<Unit>>
+    fun signUp(request: SignUpRequest): Flow<Resource<Unit>>
 
-    suspend fun login(request: LoginRequest): Flow<Resource<Unit>>
+    fun login(request: LoginRequest): Flow<Resource<Unit>>
 
-    suspend fun resetPassword(request: ResetPasswordRequest): Flow<Resource<Unit>>
+    fun resetPassword(request: ResetPasswordRequest): Flow<Resource<Unit>>
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookRepository.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookRepository.kt
@@ -1,9 +1,9 @@
 package com.android.quizcafe.core.domain.repository
 
 import com.android.quizcafe.core.domain.model.Resource
-import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
-import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBook
-import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBookDetail
+import com.android.quizcafe.core.domain.model.quizbook.response.Category
+import com.android.quizcafe.core.domain.model.quizbook.response.QuizBook
+import com.android.quizcafe.core.domain.model.quizbook.response.QuizBookDetail
 import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
 import kotlinx.coroutines.flow.Flow
 

--- a/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookRepository.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookRepository.kt
@@ -1,0 +1,17 @@
+package com.android.quizcafe.core.domain.repository
+
+import com.android.quizcafe.core.domain.model.Resource
+import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBook
+import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBookDetail
+import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
+import kotlinx.coroutines.flow.Flow
+
+interface QuizBookRepository {
+
+    fun getAllCategories(categoryRequest: CategoryRequest): Flow<Resource<List<Category>>>
+
+    fun getQuizBooksByCategory(categoryId: String): Flow<Resource<List<QuizBook>>>
+
+    fun getQuizBookById(id: Long): Flow<Resource<QuizBookDetail>>
+}

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/LoginUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/LoginUseCase.kt
@@ -9,6 +9,6 @@ import javax.inject.Inject
 class LoginUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(request: LoginRequest): Flow<Resource<Unit>> =
+    operator fun invoke(request: LoginRequest): Flow<Resource<Unit>> =
         authRepository.login(request)
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/ResetPasswordUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/ResetPasswordUseCase.kt
@@ -9,6 +9,6 @@ import javax.inject.Inject
 class ResetPasswordUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(request: ResetPasswordRequest): Flow<Resource<Unit>> =
+    operator fun invoke(request: ResetPasswordRequest): Flow<Resource<Unit>> =
         authRepository.resetPassword(request)
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/SendCodeUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/SendCodeUseCase.kt
@@ -9,6 +9,6 @@ import javax.inject.Inject
 class SendCodeUseCase @Inject constructor(
     private val authRepository: AuthRepository,
 ) {
-    suspend operator fun invoke(request: SendCodeRequest): Flow<Resource<Unit>> =
+    operator fun invoke(request: SendCodeRequest): Flow<Resource<Unit>> =
         authRepository.sendCode(request = request)
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/SignUpUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/SignUpUseCase.kt
@@ -9,6 +9,6 @@ import javax.inject.Inject
 class SignUpUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(request: SignUpRequest): Flow<Resource<Unit>> =
+    operator fun invoke(request: SignUpRequest): Flow<Resource<Unit>> =
         authRepository.signUp(request)
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/VerifyCodeUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/auth/VerifyCodeUseCase.kt
@@ -9,6 +9,6 @@ import javax.inject.Inject
 class VerifyCodeUseCase @Inject constructor(
     private val authRepository: AuthRepository
 ) {
-    suspend operator fun invoke(request: VerifyCodeRequest): Flow<Resource<Unit>> =
+    operator fun invoke(request: VerifyCodeRequest): Flow<Resource<Unit>> =
         authRepository.verifyCode(request)
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetCategoryListUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetCategoryListUseCase.kt
@@ -1,0 +1,15 @@
+package com.android.quizcafe.core.domain.usecase.quizbook
+
+import com.android.quizcafe.core.domain.model.Resource
+import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
+import com.android.quizcafe.core.domain.repository.QuizBookRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetCategoryListUseCase @Inject constructor(
+    private val quizBookRepository: QuizBookRepository
+) {
+    operator fun invoke(categoryRequest: CategoryRequest): Flow<Resource<List<Category>>> =
+        quizBookRepository.getAllCategories(categoryRequest)
+}

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetCategoryListUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetCategoryListUseCase.kt
@@ -1,7 +1,7 @@
 package com.android.quizcafe.core.domain.usecase.quizbook
 
 import com.android.quizcafe.core.domain.model.Resource
-import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.domain.model.quizbook.response.Category
 import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
 import com.android.quizcafe.core.domain.repository.QuizBookRepository
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookDetailUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookDetailUseCase.kt
@@ -1,0 +1,14 @@
+package com.android.quizcafe.core.domain.usecase.quizbook
+
+import com.android.quizcafe.core.domain.model.Resource
+import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBookDetail
+import com.android.quizcafe.core.domain.repository.QuizBookRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetQuizBookDetailUseCase @Inject constructor(
+    private val quizBookRepository: QuizBookRepository
+) {
+    operator fun invoke(quizBookId: Long): Flow<Resource<QuizBookDetail>> =
+        quizBookRepository.getQuizBookById(quizBookId)
+}

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookDetailUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookDetailUseCase.kt
@@ -1,7 +1,7 @@
 package com.android.quizcafe.core.domain.usecase.quizbook
 
 import com.android.quizcafe.core.domain.model.Resource
-import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBookDetail
+import com.android.quizcafe.core.domain.model.quizbook.response.QuizBookDetail
 import com.android.quizcafe.core.domain.repository.QuizBookRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookListUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookListUseCase.kt
@@ -1,0 +1,14 @@
+package com.android.quizcafe.core.domain.usecase.quizbook
+
+import com.android.quizcafe.core.domain.model.Resource
+import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBook
+import com.android.quizcafe.core.domain.repository.QuizBookRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetQuizBookListUseCase @Inject constructor(
+    private val quizBookRepository: QuizBookRepository
+) {
+    operator fun invoke(categoryId: String): Flow<Resource<List<QuizBook>>> =
+        quizBookRepository.getQuizBooksByCategory(categoryId)
+}

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookListUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/quizbook/GetQuizBookListUseCase.kt
@@ -1,7 +1,7 @@
 package com.android.quizcafe.core.domain.usecase.quizbook
 
 import com.android.quizcafe.core.domain.model.Resource
-import com.android.quizcafe.core.domain.model.quizbook.reponse.QuizBook
+import com.android.quizcafe.core.domain.model.quizbook.response.QuizBook
 import com.android.quizcafe.core.domain.repository.QuizBookRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject

--- a/app/src/main/java/com/android/quizcafe/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/android/quizcafe/core/network/di/NetworkModule.kt
@@ -87,7 +87,7 @@ object NetworkModule {
     @Singleton
     @Named("token")
     fun provideTokenRetrofit(
-        okHttpClient: OkHttpClient
+        @Named("token") okHttpClient: OkHttpClient
     ): Retrofit {
         val contentType = "application/json".toMediaType()
         val json = Json { ignoreUnknownKeys = true }

--- a/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceFlowMapper.kt
+++ b/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceFlowMapper.kt
@@ -4,23 +4,22 @@ import com.android.quizcafe.core.common.network.HttpStatus
 import com.android.quizcafe.core.domain.model.Resource
 import com.android.quizcafe.core.network.model.ApiResponse
 import com.android.quizcafe.core.network.model.NetworkResult
-import com.android.quizcafe.core.network.model.onSuccess
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withTimeoutOrNull
 
-fun <T : Any> apiNoResponseToResourceFlow(
+fun <T : Any> emptyApiResponseToResourceFlow(
     call: suspend () -> NetworkResult<ApiResponse<T>>
-): Flow<Resource<Unit>> = apiCallToResourceFlow(call) {
+): Flow<Resource<Unit>> = resourceFlowFromNetworkResult(call) {
     Resource.Success(Unit)
 }
 
-fun <I : Any, O : Any> apiSingleResponseToResourceFlow(
-    mapper: (I) -> O,
-    call: suspend () -> NetworkResult<ApiResponse<I>>
-): Flow<Resource<O>> = apiCallToResourceFlow(call) { data ->
+fun <T : Any, R : Any> apiResponseToResourceFlow(
+    mapper: (T) -> R,
+    call: suspend () -> NetworkResult<ApiResponse<T>>
+): Flow<Resource<R>> = resourceFlowFromNetworkResult(call) { data ->
     if (data == null) {
         Resource.Failure(DEFAULT_ERROR_MESSAGE, HttpStatus.NO_CONTENT)
     } else {
@@ -28,10 +27,10 @@ fun <I : Any, O : Any> apiSingleResponseToResourceFlow(
     }
 }
 
-fun <I : Any, O : Any> apiResponseToResourceFlow(
-    mapper: (I) -> O,
-    call: suspend () -> NetworkResult<ApiResponse<List<I>>>
-): Flow<Resource<List<O>>> = apiCallToResourceFlow(call) { data ->
+fun <T : Any, R : Any> apiResponseListToResourceFlow(
+    mapper: (T) -> R,
+    call: suspend () -> NetworkResult<ApiResponse<List<T>>>
+): Flow<Resource<List<R>>> = resourceFlowFromNetworkResult(call) { data ->
     if (data == null) {
         Resource.Failure(DEFAULT_ERROR_MESSAGE, HttpStatus.NO_CONTENT)
     } else {
@@ -39,7 +38,7 @@ fun <I : Any, O : Any> apiResponseToResourceFlow(
     }
 }
 
-private fun <T : Any, R> apiCallToResourceFlow(
+private fun <T : Any, R: Any> resourceFlowFromNetworkResult(
     call: suspend () -> NetworkResult<ApiResponse<T>>,
     onSuccess: suspend (T?) -> Resource<R>
 ): Flow<Resource<R>> = flow {

--- a/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceFlowMapper.kt
+++ b/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceFlowMapper.kt
@@ -38,7 +38,7 @@ fun <T : Any, R : Any> apiResponseListToResourceFlow(
     }
 }
 
-private fun <T : Any, R: Any> resourceFlowFromNetworkResult(
+private fun <T : Any, R : Any> resourceFlowFromNetworkResult(
     call: suspend () -> NetworkResult<ApiResponse<T>>,
     onSuccess: suspend (T?) -> Resource<R>
 ): Flow<Resource<R>> = flow {

--- a/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceFlowMapper.kt
+++ b/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceFlowMapper.kt
@@ -1,0 +1,57 @@
+package com.android.quizcafe.core.network.mapper
+
+import com.android.quizcafe.core.common.network.HttpStatus
+import com.android.quizcafe.core.domain.model.Resource
+import com.android.quizcafe.core.network.model.ApiResponse
+import com.android.quizcafe.core.network.model.NetworkResult
+import com.android.quizcafe.core.network.model.onSuccess
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withTimeoutOrNull
+
+fun <T : Any> apiNoResponseToResourceFlow(
+    call: suspend () -> NetworkResult<ApiResponse<T>>
+): Flow<Resource<Unit>> = apiCallToResourceFlow(call) {
+    Resource.Success(Unit)
+}
+
+fun <I : Any, O : Any> apiSingleResponseToResourceFlow(
+    mapper: (I) -> O,
+    call: suspend () -> NetworkResult<ApiResponse<I>>
+): Flow<Resource<O>> = apiCallToResourceFlow(call) { data ->
+    if (data == null) {
+        Resource.Failure(DEFAULT_ERROR_MESSAGE, HttpStatus.NO_CONTENT)
+    } else {
+        Resource.Success(mapper(data))
+    }
+}
+
+fun <I : Any, O : Any> apiResponseToResourceFlow(
+    mapper: (I) -> O,
+    call: suspend () -> NetworkResult<ApiResponse<List<I>>>
+): Flow<Resource<List<O>>> = apiCallToResourceFlow(call) { data ->
+    if (data == null) {
+        Resource.Failure(DEFAULT_ERROR_MESSAGE, HttpStatus.NO_CONTENT)
+    } else {
+        Resource.Success(data.map(mapper))
+    }
+}
+
+private fun <T : Any, R> apiCallToResourceFlow(
+    call: suspend () -> NetworkResult<ApiResponse<T>>,
+    onSuccess: suspend (T?) -> Resource<R>
+): Flow<Resource<R>> = flow {
+    emit(Resource.Loading)
+
+    val result = withTimeoutOrNull(3_000L) {
+        call()
+    } ?: return@flow emit(Resource.Failure("요청 시간이 초과되었습니다.", HttpStatus.REQUEST_TIMEOUT))
+
+    when (result) {
+        is NetworkResult.Success -> emit(onSuccess(result.data.data))
+        is NetworkResult.Error -> emit(Resource.Failure(result.message ?: DEFAULT_ERROR_MESSAGE, result.code))
+        is NetworkResult.Exception -> emit(handleNetworkException(result.e))
+    }
+}.flowOn(Dispatchers.IO)

--- a/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceMapper.kt
+++ b/app/src/main/java/com/android/quizcafe/core/network/mapper/ApiResponseToResourceMapper.kt
@@ -4,19 +4,18 @@ import com.android.quizcafe.core.common.network.HttpStatus
 import com.android.quizcafe.core.domain.model.Resource
 import com.android.quizcafe.core.network.model.ApiResponse
 import com.android.quizcafe.core.network.model.NetworkResult
-import com.android.quizcafe.core.network.model.onSuccess
 import kotlinx.coroutines.withTimeoutOrNull
 
-suspend fun apiNoResponseToResource(
+suspend fun emptyApiResponseToResource(
     call: suspend () -> NetworkResult<ApiResponse<Unit>>
-): Resource<Unit> = apiCallToResource(call) {
+): Resource<Unit> = resourceFromNetworkResult(call) {
     Resource.Success(Unit)
 }
 
-suspend fun <I : Any, O : Any> apiSingleResponseToResource(
-    mapper: (I) -> O,
-    call: suspend () -> NetworkResult<ApiResponse<I>>
-): Resource<O> = apiCallToResource(call) { data ->
+suspend fun <T : Any, R : Any> apiResponseToResource(
+    mapper: (T) -> R,
+    call: suspend () -> NetworkResult<ApiResponse<T>>
+): Resource<R> = resourceFromNetworkResult(call) { data ->
     if (data == null) {
         Resource.Failure(
             errorMessage = DEFAULT_ERROR_MESSAGE,
@@ -27,10 +26,10 @@ suspend fun <I : Any, O : Any> apiSingleResponseToResource(
     }
 }
 
-suspend fun <I : Any, O : Any> apiResponseToResource(
-    mapper: (I) -> O,
-    call: suspend () -> NetworkResult<ApiResponse<List<I>>>
-): Resource<List<O>> = apiCallToResource(call) { data ->
+suspend fun <T : Any, R : Any> apiResponseListToResource(
+    mapper: (T) -> R,
+    call: suspend () -> NetworkResult<ApiResponse<List<T>>>
+): Resource<List<R>> = resourceFromNetworkResult(call) { data ->
     if (data == null) {
         Resource.Failure(
             errorMessage = DEFAULT_ERROR_MESSAGE,
@@ -40,7 +39,7 @@ suspend fun <I : Any, O : Any> apiResponseToResource(
         Resource.Success(data.map(mapper))
     }
 }
-private suspend fun <T : Any, R> apiCallToResource(
+private suspend fun <T : Any, R : Any> resourceFromNetworkResult(
     call: suspend () -> NetworkResult<ApiResponse<T>>,
     onSuccess: (T?) -> Resource<R>
 ): Resource<R> {

--- a/app/src/main/java/com/android/quizcafe/core/network/mapper/HandleNetworkException.kt
+++ b/app/src/main/java/com/android/quizcafe/core/network/mapper/HandleNetworkException.kt
@@ -1,0 +1,25 @@
+package com.android.quizcafe.core.network.mapper
+
+import com.android.quizcafe.core.common.network.HttpStatus
+import com.android.quizcafe.core.domain.model.Resource
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+
+internal fun handleNetworkException(e: Throwable): Resource.Failure {
+    return when (e) {
+        is ConnectException -> Resource.Failure(
+            errorMessage = "네트워크 연결을 확인해주세요.",
+            code = HttpStatus.NETWORK_DISCONNECTED
+        )
+
+        is SocketTimeoutException -> Resource.Failure(
+            errorMessage = "서버 응답이 지연되었습니다.",
+            code = HttpStatus.REQUEST_TIMEOUT
+        )
+
+        else -> Resource.Failure(
+            errorMessage = e.message ?: DEFAULT_ERROR_MESSAGE,
+            code = HttpStatus.UNKNOWN
+        )
+    }
+}

--- a/app/src/main/java/com/android/quizcafe/core/ui/Title.kt
+++ b/app/src/main/java/com/android/quizcafe/core/ui/Title.kt
@@ -53,7 +53,7 @@ fun AnimatedTitleWithBody(
 // TopAppBar를 사용하지 않는 underline Title
 @Composable
 fun TitleWithUnderLine(title: String) {
-    Spacer(Modifier.height(60.dp))
+    Spacer(Modifier.height(40.dp))
     Text(
         text = title,
         style = quizCafeTypography().titleLarge

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/Category.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/Category.kt
@@ -1,7 +1,0 @@
-package com.android.quizcafe.feature.categorypicker
-
-// 임시 데이터 클래스
-data class Category(
-    val group: String,
-    val name: String
-)

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryContract.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryContract.kt
@@ -12,7 +12,7 @@ data class CategoryViewState(
 
 sealed class CategoryIntent : BaseContract.ViewIntent {
     data object LoadCategories : CategoryIntent()
-    data object ClickCategory : CategoryIntent()
+    data class ClickCategory(val categoryId: String) : CategoryIntent()
 
     data class SuccessGetCategories(val data: List<Category>) : CategoryIntent()
     data class FailGetCategories(val errorMessage: String? = null) : CategoryIntent()
@@ -21,5 +21,5 @@ sealed class CategoryIntent : BaseContract.ViewIntent {
 sealed class CategoryEffect : BaseContract.ViewEffect {
     data class ShowError(val message: String) : CategoryEffect()
     data object NavigateToHome : CategoryEffect()
-    data object NavigateToQuizBooks : CategoryEffect()
+    data class NavigateToQuizBooks(val categoryId: String) : CategoryEffect()
 }

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryContract.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryContract.kt
@@ -1,0 +1,25 @@
+package com.android.quizcafe.feature.categorypicker
+
+import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.ui.base.BaseContract
+
+data class CategoryViewState(
+    val quizType: String = "",
+    val categories: List<Category> = emptyList(),
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+) : BaseContract.ViewState
+
+sealed class CategoryIntent : BaseContract.ViewIntent {
+    data object LoadCategories : CategoryIntent()
+    data object ClickCategory : CategoryIntent()
+
+    data class SuccessGetCategories(val data: List<Category>) : CategoryIntent()
+    data class FailGetCategories(val errorMessage: String? = null) : CategoryIntent()
+}
+
+sealed class CategoryEffect : BaseContract.ViewEffect {
+    data class ShowError(val message: String) : CategoryEffect()
+    data object NavigateToHome : CategoryEffect()
+    data object NavigateToQuizBooks : CategoryEffect()
+}

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryContract.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryContract.kt
@@ -1,6 +1,6 @@
 package com.android.quizcafe.feature.categorypicker
 
-import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.domain.model.quizbook.response.Category
 import com.android.quizcafe.core.ui.base.BaseContract
 
 data class CategoryViewState(

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
@@ -28,7 +28,7 @@ import com.android.quizcafe.core.designsystem.theme.onPrimaryLight
 import com.android.quizcafe.core.designsystem.theme.outlineLight
 import com.android.quizcafe.core.designsystem.theme.quizCafeTypography
 import com.android.quizcafe.core.designsystem.theme.scrimLight
-import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
+import com.android.quizcafe.core.domain.model.quizbook.response.Category
 
 @Composable
 fun CategoryCardList(categories: List<Category>, onItemClicked: () -> Unit = {}) {

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
@@ -31,13 +31,13 @@ import com.android.quizcafe.core.designsystem.theme.scrimLight
 import com.android.quizcafe.core.domain.model.quizbook.response.Category
 
 @Composable
-fun CategoryCardList(categories: List<Category>, onItemClicked: () -> Unit = {}) {
+fun CategoryCardList(categories: List<Category>, onItemClicked: (String) -> Unit = {}) {
     LazyColumn {
         items(categories) { category ->
             CategoryCard(
                 category = category,
                 onCategoryItemClick = {
-                    onItemClicked()
+                    onItemClicked(category.name)
                 }
             )
         }

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerContent.kt
@@ -28,18 +28,24 @@ import com.android.quizcafe.core.designsystem.theme.onPrimaryLight
 import com.android.quizcafe.core.designsystem.theme.outlineLight
 import com.android.quizcafe.core.designsystem.theme.quizCafeTypography
 import com.android.quizcafe.core.designsystem.theme.scrimLight
+import com.android.quizcafe.core.domain.model.quizbook.reponse.Category
 
 @Composable
-fun CategoryCardList(categories: List<Category>) {
+fun CategoryCardList(categories: List<Category>, onItemClicked: () -> Unit = {}) {
     LazyColumn {
         items(categories) { category ->
-            CategoryCard(category = category)
+            CategoryCard(
+                category = category,
+                onCategoryItemClick = {
+                    onItemClicked()
+                }
+            )
         }
     }
 }
 
 @Composable
-fun CategoryCard(category: Category) {
+fun CategoryCard(category: Category, onCategoryItemClick: () -> Unit) {
     Spacer(Modifier.height(8.dp))
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -47,46 +53,56 @@ fun CategoryCard(category: Category) {
         elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
         colors = CardDefaults.cardColors(containerColor = onPrimaryLight),
         onClick = {
-            // TODO: 문제집 화면으로 이동
+            onCategoryItemClick()
         }
     ) {
         Column(
             modifier = Modifier.padding(16.dp),
             verticalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(
-                text = category.group,
-                color = outlineLight,
-                style = quizCafeTypography().bodyLarge
-            )
+            CategoryGroupText(category.group)
             Spacer(Modifier.height(8.dp))
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text = category.name,
-                    style = quizCafeTypography().titleMedium
-                )
-
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = stringResource(R.string.go),
-                    tint = scrimLight,
-                    modifier = Modifier.height(24.dp)
-                )
-            }
+            CategoryCardTitle(category.name)
         }
     }
     Spacer(Modifier.height(8.dp))
+}
+
+@Composable
+private fun CategoryCardTitle(categoryName: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = categoryName,
+            style = quizCafeTypography().titleMedium
+        )
+
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = stringResource(R.string.go),
+            tint = scrimLight,
+            modifier = Modifier.height(24.dp)
+        )
+    }
+}
+
+@Composable
+private fun CategoryGroupText(group: String) {
+    Text(
+        text = group,
+        color = outlineLight,
+        style = quizCafeTypography().bodyLarge
+    )
 }
 
 @Preview(showBackground = true)
 @Composable
 fun CategoryCardPreview() {
     QuizCafeTheme {
-        CategoryCardList(listOf(Category("그룹", "카테고리 이름"), Category("그룹", "카테고리 이름")))
+        CategoryCardList(listOf(Category("0", "그룹", "카테고리 이름"), Category("1", "그룹", "카테고리 이름")))
     }
 }

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerScreen.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -15,28 +17,27 @@ import com.android.quizcafe.core.designsystem.theme.QuizCafeTheme
 import com.android.quizcafe.core.ui.TitleWithUnderLine
 
 @Composable
-fun CategoryPickerScreen() {
-    // 임시 데이터
-    val categories = listOf(
-        Category("Computer Science", "네트워크"),
-        Category("Computer Science", "운영체제"),
-        Category("Computer Science", "알고리즘"),
-        Category("Android", "안드로이드"),
-        Category("Computer Science", "네트워크"),
-        Category("Computer Science", "운영체제"),
-        Category("Computer Science", "알고리즘"),
-        Category("Android", "안드로이드"),
-        Category("Programming Language", "코틀린")
-    )
+fun CategoryPickerScreen(
+    state: CategoryViewState = CategoryViewState(),
+    sendIntent: (CategoryIntent) -> Unit
+) {
+    val categories = state.categories
 
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
+            .navigationBarsPadding()
+            .systemBarsPadding()
     ) {
         TitleWithUnderLine(stringResource(R.string.pick_category))
         Spacer(Modifier.height(12.dp))
-        CategoryCardList(categories)
+        CategoryCardList(
+            categories = categories,
+            onItemClicked = {
+                sendIntent(CategoryIntent.ClickCategory)
+            }
+        )
     }
 }
 
@@ -44,6 +45,6 @@ fun CategoryPickerScreen() {
 @Composable
 fun CategoryPickerScreenPreview() {
     QuizCafeTheme {
-        CategoryPickerScreen()
+        CategoryPickerScreen(state = CategoryViewState()) {}
     }
 }

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryPickerScreen.kt
@@ -34,8 +34,8 @@ fun CategoryPickerScreen(
         Spacer(Modifier.height(12.dp))
         CategoryCardList(
             categories = categories,
-            onItemClicked = {
-                sendIntent(CategoryIntent.ClickCategory)
+            onItemClicked = { categoryName ->
+                sendIntent(CategoryIntent.ClickCategory(categoryName))
             }
         )
     }

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryRoute.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryRoute.kt
@@ -11,7 +11,7 @@ import com.android.quizcafe.R
 
 @Composable
 fun CategoryRoute(
-    navigateToQuizBookPicker: () -> Unit,
+    navigateToQuizBookPicker: (String) -> Unit,
     navigateToHome: () -> Unit,
     viewModel: CategoryViewModel = hiltViewModel()
 ) {
@@ -29,8 +29,8 @@ fun CategoryRoute(
                     navigateToHome()
                 }
 
-                CategoryEffect.NavigateToQuizBooks -> {
-                    navigateToQuizBookPicker()
+                is CategoryEffect.NavigateToQuizBooks -> {
+                    navigateToQuizBookPicker(effect.categoryId)
                 }
 
                 is CategoryEffect.ShowError -> {

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryRoute.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryRoute.kt
@@ -1,0 +1,51 @@
+package com.android.quizcafe.feature.categorypicker
+
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.android.quizcafe.R
+
+@Composable
+fun CategoryRoute(
+    navigateToQuizBookPicker: () -> Unit,
+    navigateToHome: () -> Unit,
+    viewModel: CategoryViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.sendIntent(CategoryIntent.LoadCategories) // API 요청
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.effect.collect { effect ->
+            when (effect) {
+                CategoryEffect.NavigateToHome -> {
+                    navigateToHome()
+                }
+
+                CategoryEffect.NavigateToQuizBooks -> {
+                    navigateToQuizBookPicker()
+                }
+
+                is CategoryEffect.ShowError -> {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.error_message),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+        }
+    }
+
+    CategoryPickerScreen(
+        state = state,
+        sendIntent = viewModel::sendIntent
+    )
+}

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryViewModel.kt
@@ -1,0 +1,60 @@
+package com.android.quizcafe.feature.categorypicker
+
+import android.util.Log
+import com.android.quizcafe.core.domain.model.Resource
+import com.android.quizcafe.core.domain.model.quizbook.request.CategoryRequest
+import com.android.quizcafe.core.domain.usecase.quizbook.GetCategoryListUseCase
+import com.android.quizcafe.core.ui.base.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CategoryViewModel @Inject constructor(
+    private val getCategoryUseCase: GetCategoryListUseCase
+) : BaseViewModel<CategoryViewState, CategoryIntent, CategoryEffect>(
+    initialState = CategoryViewState()
+) {
+
+    override suspend fun handleIntent(intent: CategoryIntent) {
+        when (intent) {
+            CategoryIntent.LoadCategories -> getCategoryList()
+            CategoryIntent.ClickCategory -> emitEffect(CategoryEffect.NavigateToQuizBooks)
+            is CategoryIntent.SuccessGetCategories -> emitEffect(CategoryEffect.NavigateToQuizBooks)
+            is CategoryIntent.FailGetCategories -> emitEffect(CategoryEffect.ShowError(intent.errorMessage ?: ""))
+        }
+    }
+
+    override fun reduce(currentState: CategoryViewState, intent: CategoryIntent): CategoryViewState {
+        return when (intent) {
+            CategoryIntent.LoadCategories -> currentState.copy(isLoading = true, errorMessage = null)
+            CategoryIntent.ClickCategory -> currentState.copy(isLoading = true, errorMessage = null)
+            is CategoryIntent.SuccessGetCategories -> currentState.copy(
+                categories = intent.data,
+                isLoading = false
+            )
+            is CategoryIntent.FailGetCategories -> currentState.copy(isLoading = false, errorMessage = "로그인에 실패했습니다.")
+        }
+    }
+
+    private suspend fun CategoryViewModel.getCategoryList() {
+        getCategoryUseCase(
+            CategoryRequest(quizType = state.value.quizType)
+        ).collect {
+            when (it) {
+                is Resource.Success -> {
+                    Log.d("category", "Get Category List Success")
+                    sendIntent(CategoryIntent.SuccessGetCategories(it.data))
+                }
+
+                is Resource.Loading -> {
+                    Log.d("category", "Loading")
+                }
+
+                is Resource.Failure -> {
+                    Log.d("category", "Get Category List Fail")
+                    sendIntent(CategoryIntent.FailGetCategories(it.errorMessage))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/categorypicker/CategoryViewModel.kt
@@ -18,8 +18,8 @@ class CategoryViewModel @Inject constructor(
     override suspend fun handleIntent(intent: CategoryIntent) {
         when (intent) {
             CategoryIntent.LoadCategories -> getCategoryList()
-            CategoryIntent.ClickCategory -> emitEffect(CategoryEffect.NavigateToQuizBooks)
-            is CategoryIntent.SuccessGetCategories -> emitEffect(CategoryEffect.NavigateToQuizBooks)
+            is CategoryIntent.ClickCategory -> emitEffect(CategoryEffect.NavigateToQuizBooks(intent.categoryId))
+            is CategoryIntent.SuccessGetCategories -> {}
             is CategoryIntent.FailGetCategories -> emitEffect(CategoryEffect.ShowError(intent.errorMessage ?: ""))
         }
     }
@@ -27,11 +27,8 @@ class CategoryViewModel @Inject constructor(
     override fun reduce(currentState: CategoryViewState, intent: CategoryIntent): CategoryViewState {
         return when (intent) {
             CategoryIntent.LoadCategories -> currentState.copy(isLoading = true, errorMessage = null)
-            CategoryIntent.ClickCategory -> currentState.copy(isLoading = true, errorMessage = null)
-            is CategoryIntent.SuccessGetCategories -> currentState.copy(
-                categories = intent.data,
-                isLoading = false
-            )
+            is CategoryIntent.ClickCategory -> currentState.copy(isLoading = true, errorMessage = null)
+            is CategoryIntent.SuccessGetCategories -> currentState.copy(categories = intent.data, isLoading = false)
             is CategoryIntent.FailGetCategories -> currentState.copy(isLoading = false, errorMessage = "로그인에 실패했습니다.")
         }
     }


### PR DESCRIPTION
## Description

- [x] QuizBookRepository 구현
- [x] QuizBookDataSource 구현
- [x] QuizBookService 구현
- [x] GetCategoriesUsecase 구현
- [x] CategoryViewModel 구현
- [x] APIResultToResourceMapper 로직 개선
---
## Summary
APIResultToResourceMapper 파일을 flow인 경우와 아닌 경우 파일을 분리하였습니다.
response dto 변환 로직을 추가하였습니다.

1. apiNoResponseToResourceFlow -> ApiResult.data 가 null 인 경우 사용

아래 두 함수는 응답 데이터가 존재하므로 mapper 람다 파라미터를 가짐

2. apiSingleResponseToResourceFlow -> ApiResult.data가 단일 데이터인 경우 사용 (List 아님)
3. apiResponseToResourceFlow -> ApiResult.data가 List인 경우 사용

---
## Test
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 단위 테스트 또는 통합 테스트를 추가했습니다.
- [ ] UI 테스트를 진행했습니다.
- [ ] CI 테스트까지 완료했습니다.

---
