### PR TITLE
[SQC-145] 이전 문제 조회하기 및 한문제씩 풀기 모드 구현

### DIFF
--- a/INTENT_FLOW_DIAGRAM.md
+++ b/INTENT_FLOW_DIAGRAM.md
@@ -1,0 +1,132 @@
+# QuizSolve Intent Flow Diagram
+
+## 개선된 Intent 구조
+
+### 1. Initialization & Data Loading
+```
+Initialize(quizBookId) 
+├── loadQuizBook() → LoadQuizBookSuccess(quizBook)
+└── getQuizBookLocalId() → SetQuizBookLocalId(localId) → LoadQuizBookGradeSuccess(grade)
+```
+
+### 2. User Interaction
+```
+SelectAnswer(option) → Update MCQ State
+UpdateSubjectiveAnswer(answer) → Update Subjective State
+```
+
+### 3. Navigation
+```
+NavigateBack → NavigatePopBack Effect
+NavigateToNextQuestion → SubmitCurrentAnswer → GradeQuizSuccess
+NavigateToPreviousQuestion → getQuizAnswer() → GradeQuizSuccess
+NavigateToResult → SubmitQuizBookSuccess → NavigateToQuizBookSolvingResult Effect
+```
+
+### 4. Quiz Submission & Grading
+```
+SubmitCurrentAnswer → saveQuizToLocal() → GradeQuizSuccess
+SubmitAllAnswers → submitQuizAnswer() → SubmitQuizBookSuccess
+HandleError(message) → ShowErrorDialog Effect
+```
+
+### 5. Timer
+```
+UpdateTimer → Update Timer State (every 1 second)
+```
+
+## Intent 분류 및 개선사항
+
+### ✅ 개선된 점들:
+
+1. **명확한 네이밍**
+   - `LoadQuizBook` → `Initialize`
+   - `SelectOption` → `SelectAnswer`
+   - `UpdatedSubjectiveAnswer` → `UpdateSubjectiveAnswer`
+   - `OnBackClick` → `NavigateBack`
+   - `TickTime` → `UpdateTimer`
+
+2. **논리적 그룹핑**
+   - **Initialization & Data Loading**: 초기화 및 데이터 로딩 관련
+   - **User Interaction**: 사용자 입력 관련
+   - **Navigation**: 네비게이션 관련
+   - **Quiz Submission & Grading**: 퀴즈 제출 및 채점 관련
+   - **Timer**: 타이머 관련
+
+3. **의도 명확화**
+   - `SubmitNext` → `NavigateToNextQuestion`
+   - `SubmitPrev` → `NavigateToPreviousQuestion`
+   - `SubmitAnswer` → `SubmitAllAnswers`
+   - `GradeQuizError` → `HandleError`
+
+4. **일관성 있는 네이밍**
+   - 모든 네비게이션 관련: `Navigate*`
+   - 모든 제출 관련: `Submit*`
+   - 모든 로딩 관련: `Load*` 또는 `Initialize`
+
+## 전체 흐름도
+
+```
+[Screen Load] 
+    ↓
+Initialize(quizBookId)
+    ↓
+├── LoadQuizBookSuccess → Update UI State
+└── SetQuizBookLocalId → LoadQuizBookGradeSuccess → Update UI State
+    ↓
+[User Interaction]
+    ↓
+├── SelectAnswer → Update MCQ State
+├── UpdateSubjectiveAnswer → Update Subjective State
+└── UpdateTimer → Update Timer State
+    ↓
+[Navigation Actions]
+    ↓
+├── NavigateBack → NavigatePopBack Effect
+├── NavigateToNextQuestion → SubmitCurrentAnswer → GradeQuizSuccess
+├── NavigateToPreviousQuestion → getQuizAnswer() → GradeQuizSuccess
+└── NavigateToResult → SubmitQuizBookSuccess → NavigateToQuizBookSolvingResult Effect
+    ↓
+[Error Handling]
+    ↓
+HandleError → ShowErrorDialog Effect
+```
+
+## 사용 예시
+
+### 1. 퀴즈북 초기화
+```kotlin
+sendIntent(QuizSolveIntent.Initialize(quizBookId))
+```
+
+### 2. 답안 선택
+```kotlin
+sendIntent(QuizSolveIntent.SelectAnswer(option))
+sendIntent(QuizSolveIntent.UpdateSubjectiveAnswer(answer))
+```
+
+### 3. 네비게이션
+```kotlin
+sendIntent(QuizSolveIntent.NavigateBack)
+sendIntent(QuizSolveIntent.NavigateToNextQuestion)
+sendIntent(QuizSolveIntent.NavigateToPreviousQuestion)
+```
+
+### 4. 퀴즈 제출
+```kotlin
+sendIntent(QuizSolveIntent.SubmitCurrentAnswer)
+sendIntent(QuizSolveIntent.SubmitAllAnswers)
+```
+
+### 5. 에러 처리
+```kotlin
+sendIntent(QuizSolveIntent.HandleError("에러 메시지"))
+```
+
+## 장점
+
+1. **가독성 향상**: 명확한 네이밍으로 코드 이해도 증가
+2. **유지보수성**: 논리적 그룹핑으로 관련 기능 찾기 쉬움
+3. **확장성**: 새로운 기능 추가 시 적절한 그룹에 배치 가능
+4. **일관성**: 일관된 네이밍 컨벤션으로 코드 품질 향상
+5. **디버깅**: 명확한 의도로 디버깅 시 추적 용이 

--- a/app/schemas/com.android.quizcafe.core.database.QuizCafeDatabase/2.json
+++ b/app/schemas/com.android.quizcafe.core.database.QuizCafeDatabase/2.json
@@ -1,8 +1,8 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 1,
-    "identityHash": "e8b0c98f11a3e10bbae77fa64b2c1a67",
+    "version": 2,
+    "identityHash": "1f65732a246e7baadcdcb5a5f1df98d6",
     "entities": [
       {
         "tableName": "quiz",
@@ -124,7 +124,7 @@
       },
       {
         "tableName": "QuizGradeEntity",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `serverId` INTEGER, `quizId` INTEGER NOT NULL, `quizBookGradeLocalId` INTEGER NOT NULL, `userAnswer` TEXT NOT NULL, `memo` TEXT, `isCorrect` INTEGER NOT NULL, `completedAt` TEXT NOT NULL, FOREIGN KEY(`quizBookGradeLocalId`) REFERENCES `QuizBookGradeEntity`(`localId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`localId` INTEGER NOT NULL, `serverId` INTEGER, `quizId` INTEGER NOT NULL, `quizBookGradeLocalId` INTEGER NOT NULL, `userAnswer` TEXT NOT NULL, `memo` TEXT, `isCorrect` INTEGER NOT NULL, `completedAt` TEXT NOT NULL, PRIMARY KEY(`quizBookGradeLocalId`, `quizId`), FOREIGN KEY(`quizBookGradeLocalId`) REFERENCES `QuizBookGradeEntity`(`localId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "localId",
@@ -176,9 +176,10 @@
           }
         ],
         "primaryKey": {
-          "autoGenerate": true,
+          "autoGenerate": false,
           "columnNames": [
-            "localId"
+            "quizBookGradeLocalId",
+            "quizId"
           ]
         },
         "indices": [
@@ -190,16 +191,6 @@
             ],
             "orders": [],
             "createSql": "CREATE INDEX IF NOT EXISTS `index_QuizGradeEntity_quizBookGradeLocalId` ON `${TABLE_NAME}` (`quizBookGradeLocalId`)"
-          },
-          {
-            "name": "index_QuizGradeEntity_quizId_quizBookGradeLocalId",
-            "unique": true,
-            "columnNames": [
-              "quizId",
-              "quizBookGradeLocalId"
-            ],
-            "orders": [],
-            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_QuizGradeEntity_quizId_quizBookGradeLocalId` ON `${TABLE_NAME}` (`quizId`, `quizBookGradeLocalId`)"
           }
         ],
         "foreignKeys": [
@@ -324,7 +315,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e8b0c98f11a3e10bbae77fa64b2c1a67')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1f65732a246e7baadcdcb5a5f1df98d6')"
     ]
   }
 }

--- a/app/src/main/java/com/android/quizcafe/core/data/mapper/quiz/QuizMapper.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/mapper/quiz/QuizMapper.kt
@@ -24,7 +24,7 @@ fun QuizResponseDto.toDomain() = Quiz(
     content = content,
     answer = answer,
     explanation = explanation,
-    mcqOption = mcqOption.fastMap { it.toDomain() }
+    mcqOption = mcqOption?.fastMap { it.toDomain() }
 )
 
 fun QuizWithMcqOptionsRelation.toDomain() = Quiz(

--- a/app/src/main/java/com/android/quizcafe/core/data/model/quiz/QuizResponseDto.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/model/quiz/QuizResponseDto.kt
@@ -10,5 +10,5 @@ data class QuizResponseDto(
     val content: String,
     val answer: String,
     val explanation: String?,
-    val mcqOption: List<McqOptionDto> = emptyList()
+    val mcqOption: List<McqOptionDto>? = null
 )

--- a/app/src/main/java/com/android/quizcafe/core/data/remote/datasource/QuizBookSolvingRemoteDataSource.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/remote/datasource/QuizBookSolvingRemoteDataSource.kt
@@ -1,6 +1,5 @@
 package com.android.quizcafe.core.data.remote.datasource
 
-import android.util.Log
 import com.android.quizcafe.core.data.model.solving.request.QuizBookSolvingRequestDto
 import com.android.quizcafe.core.data.model.solving.response.QuizBookSolvingResponseDto
 import com.android.quizcafe.core.data.remote.service.QuizBookSolvingService
@@ -19,7 +18,6 @@ class QuizBookSolvingRemoteDataSource @Inject constructor(
         quizBookSolvingId: Long
     ): NetworkResult<ApiResponse<QuizBookSolvingResponseDto>> =
         quizBookSolvingService.getQuizBookSolving(quizBookSolvingId)
-
 
     suspend fun solveQuizBook(
         request: QuizBookSolvingRequestDto

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookRepositoryImpl.kt
@@ -82,9 +82,12 @@ class QuizBookRepositoryImpl @Inject constructor(
         val quizEntities = quizBookDto.quizzes.map { it.toEntity() }
         quizDao.upsertQuizList(quizEntities)
 
-        val mcqOptionEntities = quizBookDto.quizzes.flatMap { quizDto ->
-            quizDto.mcqOption.map { it.toEntity() }
-        }
+        val mcqOptionEntities = quizBookDto.quizzes
+            .flatMap { quizDto ->
+                quizDto.mcqOption
+                    ?.map { it.toEntity() }
+                    ?: emptyList()
+            }
         if (mcqOptionEntities.isNotEmpty()) {
             quizDao.upsertMcqOptions(mcqOptionEntities)
         }

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.android.quizcafe.core.data.mapper.quiz.toDomain
 import com.android.quizcafe.core.data.mapper.solving.toDomain
 import com.android.quizcafe.core.data.mapper.quiz.toEntity
 import com.android.quizcafe.core.data.mapper.quizbook.toDomain
-import com.android.quizcafe.core.data.mapper.solving.toDomain
 import com.android.quizcafe.core.data.model.solving.request.McqOptionSolvingRequestDto
 import com.android.quizcafe.core.data.model.solving.request.QuizBookSolvingRequestDto
 import com.android.quizcafe.core.data.model.solving.request.QuizSolvingRequestDto

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
@@ -67,10 +67,11 @@ class QuizBookSolvingRepositoryImpl @Inject constructor(
         emit(Resource.Loading)
         val quizGradeRelation = quizGradeDao.getQuizGradeByQuizId(quizId.value, quizBookGradeLocalId.value)
         val quizGrade = quizGradeRelation?.toDomain()
-        if(quizGrade == null)
+        if (quizGrade == null) {
             emit(Resource.Failure(errorMessage = "퀴즈 Grade 조회 실패", code = LocalErrorCode.ROOM_ERROR))
-        else
+        } else {
             emit(Resource.Success(quizGrade))
+        }
     }.catch { e ->
         emit(Resource.Failure(errorMessage = "퀴즈 한문제씩 가져오다가 오류: ${e.message}", code = LocalErrorCode.ROOM_ERROR))
     }

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.android.quizcafe.core.data.repository
 
-import android.util.Log
 import com.android.quizcafe.core.common.network.HttpStatus
+import com.android.quizcafe.core.data.mapper.quiz.toDomain
 import com.android.quizcafe.core.data.mapper.solving.toDomain
 import com.android.quizcafe.core.data.mapper.quiz.toEntity
 import com.android.quizcafe.core.data.mapper.quizbook.toDomain
@@ -25,6 +25,7 @@ import com.android.quizcafe.core.domain.model.solving.QuizBookGrade
 import com.android.quizcafe.core.domain.model.value.QuizBookGradeLocalId
 import com.android.quizcafe.core.domain.model.value.QuizBookGradeServerId
 import com.android.quizcafe.core.domain.model.value.QuizBookId
+import com.android.quizcafe.core.domain.model.value.QuizId
 import com.android.quizcafe.core.domain.repository.QuizBookSolvingRepository
 import com.android.quizcafe.core.network.mapper.apiResponseListToResourceFlow
 import com.android.quizcafe.core.network.mapper.apiResponseToResource
@@ -35,6 +36,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 import kotlin.collections.map
+
 class QuizBookSolvingRepositoryImpl @Inject constructor(
     private val quizGradeDao: QuizGradeDao,
     private val quizDao: QuizDao,
@@ -59,6 +61,15 @@ class QuizBookSolvingRepositoryImpl @Inject constructor(
         }
     }.catch { e ->
         emit(Resource.Failure(errorMessage = "QuizBookGrade 생성 중 오류: ${e.message}", code = LocalErrorCode.ROOM_ERROR))
+    }
+
+    override fun getQuizGrade(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId): Flow<Resource<QuizGrade?>> = flow {
+        emit(Resource.Loading)
+        val quizGradeRelation = quizGradeDao.getQuizGradeByQuizId(quizId.value, quizBookGradeLocalId.value)
+        val quizBookGrade = quizGradeRelation?.toDomain()
+        emit(Resource.Success(quizBookGrade))
+    }.catch { e ->
+        emit(Resource.Failure(errorMessage = "퀴즈 한문제씩 가져오다가 오류: ${e.message}", code = LocalErrorCode.ROOM_ERROR))
     }
 
     // 퀴즈북 풀이 기록 가져오기

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
@@ -63,11 +63,14 @@ class QuizBookSolvingRepositoryImpl @Inject constructor(
         emit(Resource.Failure(errorMessage = "QuizBookGrade 생성 중 오류: ${e.message}", code = LocalErrorCode.ROOM_ERROR))
     }
 
-    override fun getQuizGrade(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId): Flow<Resource<QuizGrade?>> = flow {
+    override fun getQuizGrade(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId): Flow<Resource<QuizGrade>> = flow {
         emit(Resource.Loading)
         val quizGradeRelation = quizGradeDao.getQuizGradeByQuizId(quizId.value, quizBookGradeLocalId.value)
         val quizGrade = quizGradeRelation?.toDomain()
-        emit(Resource.Success(quizGrade))
+        if(quizGrade == null)
+            emit(Resource.Failure(errorMessage = "퀴즈 Grade 조회 실패", code = LocalErrorCode.ROOM_ERROR))
+        else
+            emit(Resource.Success(quizGrade))
     }.catch { e ->
         emit(Resource.Failure(errorMessage = "퀴즈 한문제씩 가져오다가 오류: ${e.message}", code = LocalErrorCode.ROOM_ERROR))
     }

--- a/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/data/repository/QuizBookSolvingRepositoryImpl.kt
@@ -66,8 +66,8 @@ class QuizBookSolvingRepositoryImpl @Inject constructor(
     override fun getQuizGrade(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId): Flow<Resource<QuizGrade?>> = flow {
         emit(Resource.Loading)
         val quizGradeRelation = quizGradeDao.getQuizGradeByQuizId(quizId.value, quizBookGradeLocalId.value)
-        val quizBookGrade = quizGradeRelation?.toDomain()
-        emit(Resource.Success(quizBookGrade))
+        val quizGrade = quizGradeRelation?.toDomain()
+        emit(Resource.Success(quizGrade))
     }.catch { e ->
         emit(Resource.Failure(errorMessage = "퀴즈 한문제씩 가져오다가 오류: ${e.message}", code = LocalErrorCode.ROOM_ERROR))
     }

--- a/app/src/main/java/com/android/quizcafe/core/database/dao/quiz/QuizGradeDao.kt
+++ b/app/src/main/java/com/android/quizcafe/core/database/dao/quiz/QuizGradeDao.kt
@@ -4,10 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Upsert
-import com.android.quizcafe.core.database.model.grading.QuizBookGradeWithQuizGradesRelation
 import com.android.quizcafe.core.database.model.grading.QuizGradeEntity
-import com.android.quizcafe.core.database.model.quiz.McqOptionEntity
 
 @Dao
 interface QuizGradeDao {
@@ -16,5 +13,5 @@ interface QuizGradeDao {
     suspend fun upsert(entity: QuizGradeEntity): Long
 
     @Query("SELECT * FROM QuizGradeEntity WHERE quizId = :quizId AND quizBookGradeLocalId = :quizBookGradeLocalId")
-    suspend fun getQuizGradeByQuizId(quizId: Long,quizBookGradeLocalId : Long): QuizGradeEntity?
+    suspend fun getQuizGradeByQuizId(quizId: Long, quizBookGradeLocalId: Long): QuizGradeEntity?
 }

--- a/app/src/main/java/com/android/quizcafe/core/database/dao/quiz/QuizGradeDao.kt
+++ b/app/src/main/java/com/android/quizcafe/core/database/dao/quiz/QuizGradeDao.kt
@@ -1,12 +1,20 @@
 package com.android.quizcafe.core.database.dao.quiz
 
 import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
 import androidx.room.Upsert
+import com.android.quizcafe.core.database.model.grading.QuizBookGradeWithQuizGradesRelation
 import com.android.quizcafe.core.database.model.grading.QuizGradeEntity
+import com.android.quizcafe.core.database.model.quiz.McqOptionEntity
 
 @Dao
 interface QuizGradeDao {
 
-    @Upsert
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun upsert(entity: QuizGradeEntity): Long
+
+    @Query("SELECT * FROM QuizGradeEntity WHERE quizId = :quizId AND quizBookGradeLocalId = :quizBookGradeLocalId")
+    suspend fun getQuizGradeByQuizId(quizId: Long,quizBookGradeLocalId : Long): QuizGradeEntity?
 }

--- a/app/src/main/java/com/android/quizcafe/core/database/model/grading/QuizGradeEntity.kt
+++ b/app/src/main/java/com/android/quizcafe/core/database/model/grading/QuizGradeEntity.kt
@@ -14,7 +14,9 @@ import androidx.room.PrimaryKey
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index(value = ["quizBookGradeLocalId"])]
+    indices = [
+        Index(value = ["quizBookGradeLocalId"]),
+        Index(value = ["quizId", "quizBookGradeLocalId"], unique = true)]
 )
 data class QuizGradeEntity(
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/com/android/quizcafe/core/database/model/grading/QuizGradeEntity.kt
+++ b/app/src/main/java/com/android/quizcafe/core/database/model/grading/QuizGradeEntity.kt
@@ -16,7 +16,8 @@ import androidx.room.PrimaryKey
     ],
     indices = [
         Index(value = ["quizBookGradeLocalId"]),
-        Index(value = ["quizId", "quizBookGradeLocalId"], unique = true)]
+        Index(value = ["quizId", "quizBookGradeLocalId"], unique = true)
+    ]
 )
 data class QuizGradeEntity(
     @PrimaryKey(autoGenerate = true)

--- a/app/src/main/java/com/android/quizcafe/core/domain/model/quiz/Quiz.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/model/quiz/Quiz.kt
@@ -10,5 +10,5 @@ data class Quiz(
     val content: String,
     val answer: String,
     val explanation: String?,
-    val mcqOption: List<McqOption> = emptyList()
+    val mcqOption: List<McqOption>? = null
 )

--- a/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookSolvingRepository.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookSolvingRepository.kt
@@ -15,7 +15,7 @@ interface QuizBookSolvingRepository {
     fun createEmptyQuizBookGrade(id: QuizBookId): Flow<Resource<QuizBookGradeLocalId>>
 
     // 퀴즈 풀이 로컬 기록 가져오기
-    fun getQuizGrade(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId): Flow<Resource<QuizGrade?>>
+    fun getQuizGrade(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId): Flow<Resource<QuizGrade>>
 
     // 퀴즈북 풀이 로컬 기록 가져오기
     fun getQuizBookGrade(id: QuizBookGradeLocalId): Flow<Resource<QuizBookGrade>>

--- a/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookSolvingRepository.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/repository/QuizBookSolvingRepository.kt
@@ -7,11 +7,15 @@ import com.android.quizcafe.core.domain.model.solving.QuizBookGrade
 import com.android.quizcafe.core.domain.model.value.QuizBookGradeLocalId
 import com.android.quizcafe.core.domain.model.value.QuizBookGradeServerId
 import com.android.quizcafe.core.domain.model.value.QuizBookId
+import com.android.quizcafe.core.domain.model.value.QuizId
 import kotlinx.coroutines.flow.Flow
 
 interface QuizBookSolvingRepository {
 
     fun createEmptyQuizBookGrade(id: QuizBookId): Flow<Resource<QuizBookGradeLocalId>>
+
+    // 퀴즈 풀이 로컬 기록 가져오기
+    fun getQuizGrade(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId): Flow<Resource<QuizGrade?>>
 
     // 퀴즈북 풀이 로컬 기록 가져오기
     fun getQuizBookGrade(id: QuizBookGradeLocalId): Flow<Resource<QuizBookGrade>>

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/GetQuizGradeUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/GetQuizGradeUseCase.kt
@@ -1,0 +1,16 @@
+package com.android.quizcafe.core.domain.usecase.solving
+
+import com.android.quizcafe.core.domain.model.value.QuizBookGradeLocalId
+import com.android.quizcafe.core.domain.model.value.QuizId
+import com.android.quizcafe.core.domain.repository.QuizBookSolvingRepository
+import javax.inject.Inject
+
+/**
+ * QuizGrade 가져오기(이전 문제 풀이 기록에 사용)
+ */
+class GetQuizGradeUseCase @Inject constructor(
+    private val quizBookSolvingRepository: QuizBookSolvingRepository
+) {
+    operator fun invoke(quizBookGradeLocalId: QuizBookGradeLocalId,quizId: QuizId,) =
+        quizBookSolvingRepository.getQuizGrade(quizBookGradeLocalId,quizId)
+}

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/GetQuizGradeUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/GetQuizGradeUseCase.kt
@@ -11,6 +11,6 @@ import javax.inject.Inject
 class GetQuizGradeUseCase @Inject constructor(
     private val quizBookSolvingRepository: QuizBookSolvingRepository
 ) {
-    operator fun invoke(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId,) =
+    operator fun invoke(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId) =
         quizBookSolvingRepository.getQuizGrade(quizBookGradeLocalId, quizId)
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/GetQuizGradeUseCase.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/GetQuizGradeUseCase.kt
@@ -11,6 +11,6 @@ import javax.inject.Inject
 class GetQuizGradeUseCase @Inject constructor(
     private val quizBookSolvingRepository: QuizBookSolvingRepository
 ) {
-    operator fun invoke(quizBookGradeLocalId: QuizBookGradeLocalId,quizId: QuizId,) =
-        quizBookSolvingRepository.getQuizGrade(quizBookGradeLocalId,quizId)
+    operator fun invoke(quizBookGradeLocalId: QuizBookGradeLocalId, quizId: QuizId,) =
+        quizBookSolvingRepository.getQuizGrade(quizBookGradeLocalId, quizId)
 }

--- a/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/gradingStrategy/GradingStrategyImpl.kt
+++ b/app/src/main/java/com/android/quizcafe/core/domain/usecase/solving/gradingStrategy/GradingStrategyImpl.kt
@@ -12,7 +12,7 @@ class McqGradingStrategy : GradingStrategy {
     override fun grade(quiz: Quiz, userAnswer: String): Boolean {
         return try {
             val correctIndex = quiz.answer.toInt() - 1
-            val correctAnswer = quiz.mcqOption[correctIndex].optionContent
+            val correctAnswer = quiz.mcqOption?.get(correctIndex)?.optionContent
             correctAnswer.equals(userAnswer, ignoreCase = true)
         } catch (e: Exception) {
             false

--- a/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.android.quizcafe.feature.main
 
-import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding

--- a/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.android.quizcafe.feature.main
 
+import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -128,7 +129,6 @@ fun MainBottomNavHost(
             )
         ) { backStackEntry ->
             val quizBookId = backStackEntry.arguments?.getLong("quizBookId") ?: 0L
-
             QuizBookDetailRoute(
                 quizBookId = quizBookId,
                 navigateToQuizBookPicker = {},

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveRoute.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveRoute.kt
@@ -24,8 +24,7 @@ fun QuizSolveRoute(
     val state by viewModel.state.collectAsState()
 
     LaunchedEffect(Unit) {
-        viewModel.sendIntent(QuizSolveIntent.LoadQuizBook(quizBookId))
-        viewModel.sendIntent(QuizSolveIntent.GetQuizBookLocalId(quizBookId))
+        viewModel.sendIntent(QuizSolveIntent.Initialize(quizBookId))
     }
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
@@ -49,7 +49,7 @@ fun QuizSolveScreen(
     Scaffold(
         topBar = {
             QuizTopBar(
-                currentQuestion = uiState.common.currentIndex+1,
+                currentQuestion = uiState.common.currentIndex + 1,
                 totalQuestions = uiState.quizBook?.totalQuizzes ?: 0,
                 timeText = uiState.getTimeText(),
                 onBackClick = { onIntent(QuizSolveIntent.NavigateBack) },
@@ -110,8 +110,6 @@ fun QuizSolveScreen(
                     }
                 }
             }
-
-
         }
     }
 }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
@@ -66,9 +66,10 @@ fun QuizSolveScreen(
             QuizSolveBottomBar(
                 isEnabled = uiState.common.isButtonEnabled,
                 isLastQuestion = uiState.isLastQuestion,
-                isWrongAnswer = uiState.isWrongAnswer,
-                onClickAction = onClickAction,
-                textRes = textRes
+                isFirstQuestion = uiState.isFirstQuestion,
+                onClickActionPrev = { onIntent(QuizSolveIntent.SubmitPrev) },
+                onClickActionNext = onClickAction,
+                textRes = textRightRes
             )
         }
     ) { padding ->
@@ -125,28 +126,59 @@ fun QuizSolveScreen(
 private fun QuizSolveBottomBar(
     isEnabled: Boolean,
     isLastQuestion: Boolean,
-    isWrongAnswer: Boolean,
-    onClickAction: () -> Unit,
+    isFirstQuestion: Boolean,
+    onClickActionPrev: () -> Unit,
+    onClickActionNext: () -> Unit,
     textRes: Int
 ) {
-    QuizCafeButton(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp),
-        enabled = isEnabled,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = if (isLastQuestion || isWrongAnswer) yellow_200 else primaryLight,
-            contentColor = scrimLight,
-            disabledContainerColor = surfaceDimLight
-        ),
-        onClick = onClickAction,
-        text = {
-            Text(
-                text = stringResource(textRes),
-                style = quizCafeTypography().titleSmall
+    Row(
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        if (!isFirstQuestion) {
+            QuizCafeButton(
+                modifier = Modifier
+                    .weight(1F)
+                    .padding(horizontal = 16.dp),
+                enabled = true,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = if (isLastQuestion) primaryLight else yellow_200,
+                    contentColor = scrimLight,
+                    disabledContainerColor = surfaceDimLight
+                ),
+                onClick = onClickActionPrev,
+                text = {
+                    Text(
+                        text = stringResource(R.string.solve_btn_prev_text),
+                        style = quizCafeTypography().titleSmall
+                    )
+                }
+            )
+        } else {
+            Spacer(
+                modifier = Modifier
+                    .weight(1F)
+                    .padding(horizontal = 16.dp)
             )
         }
-    )
+        QuizCafeButton(
+            modifier = Modifier
+                .weight(1F)
+                .padding(horizontal = 16.dp),
+            enabled = isEnabled,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = yellow_200,
+                contentColor = scrimLight,
+                disabledContainerColor = surfaceDimLight
+            ),
+            onClick = onClickActionNext,
+            text = {
+                Text(
+                    text = stringResource(textRes),
+                    style = quizCafeTypography().titleSmall
+                )
+            }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
@@ -46,19 +46,13 @@ fun QuizSolveScreen(
         uiState.isLastQuestion -> R.string.solve_btn_submit
         else -> R.string.solve_btn_next_text
     }
-    val onClickAction = {
-        when {
-            uiState.isWrongAnswer -> onIntent(QuizSolveIntent.ShowExplanation)
-            else -> onIntent(QuizSolveIntent.SubmitNext)
-        }
-    }
     Scaffold(
         topBar = {
             QuizTopBar(
                 currentQuestion = uiState.questionInfo.current,
                 totalQuestions = uiState.questionInfo.total,
                 timeText = uiState.getTimeText(),
-                onBackClick = { onIntent(QuizSolveIntent.OnBackClick) },
+                onBackClick = { onIntent(QuizSolveIntent.NavigateBack) },
                 onSideBarClick = { /* 사이드바 보여줘? 말어 */ },
             )
         },
@@ -67,8 +61,8 @@ fun QuizSolveScreen(
                 isEnabled = uiState.common.isButtonEnabled,
                 isLastQuestion = uiState.isLastQuestion,
                 isFirstQuestion = uiState.isFirstQuestion,
-                onClickActionPrev = { onIntent(QuizSolveIntent.SubmitPrev) },
-                onClickActionNext = onClickAction,
+                onClickActionPrev = { onIntent(QuizSolveIntent.NavigateToPreviousQuestion) },
+                onClickActionNext = { onIntent(QuizSolveIntent.NavigateToNextQuestion) },
                 textRes = textRightRes
             )
         }
@@ -153,12 +147,6 @@ private fun QuizSolveBottomBar(
                     )
                 }
             )
-        } else {
-            Spacer(
-                modifier = Modifier
-                    .weight(1F)
-                    .padding(horizontal = 16.dp)
-            )
         }
         QuizCafeButton(
             modifier = Modifier
@@ -190,7 +178,7 @@ fun SubjectiveAnswerSection(
     UnderlinedTextField(
         modifier = modifier,
         value = uiState.subjective.answer,
-        onValueChange = { onIntent(QuizSolveIntent.UpdatedSubjectiveAnswer(it)) },
+        onValueChange = { onIntent(QuizSolveIntent.UpdateSubjectiveAnswer(it)) },
         maxCharCount = uiState.subjective.maxCharCount,
         showCharCount = uiState.subjective.showCharCount,
         answerState = uiState.review.answerState
@@ -220,7 +208,7 @@ fun SelectMultipleChoiceSection(
                 answerState = uiState.getOptionState(option),
                 index = idx + 1,
                 content = option.text,
-                onClick = { onIntent(QuizSolveIntent.SelectOption(option)) }
+                onClick = { onIntent(QuizSolveIntent.SelectAnswer(option)) }
             )
         }
     }
@@ -247,7 +235,7 @@ fun SelectOXSection(
                 modifier = modifier.weight(1F),
                 answerState = uiState.getOptionState(option),
                 iconPaint = if (option.text == "O") R.drawable.ic_ox_option_o else R.drawable.ic_ox_option_x,
-                onClick = { onIntent(QuizSolveIntent.SelectOption(option)) }
+                onClick = { onIntent(QuizSolveIntent.SelectAnswer(option)) }
             )
         }
     }
@@ -256,7 +244,7 @@ fun SelectOXSection(
 @Composable
 fun QuizTitleSection(modifier: Modifier = Modifier, questionText: String) {
     Text(
-        text = "Q.$questionText",
+        text = questionText,
         style = quizCafeTypography().titleMedium,
         modifier = modifier.fillMaxWidth()
     )

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
@@ -49,8 +49,8 @@ fun QuizSolveScreen(
     Scaffold(
         topBar = {
             QuizTopBar(
-                currentQuestion = uiState.questionInfo.current,
-                totalQuestions = uiState.questionInfo.total,
+                currentQuestion = uiState.common.currentIndex+1,
+                totalQuestions = uiState.quizBook?.totalQuizzes ?: 0,
                 timeText = uiState.getTimeText(),
                 onBackClick = { onIntent(QuizSolveIntent.NavigateBack) },
                 onSideBarClick = { /* 사이드바 보여줘? 말어 */ },
@@ -58,7 +58,7 @@ fun QuizSolveScreen(
         },
         bottomBar = {
             QuizSolveBottomBar(
-                isEnabled = uiState.common.isButtonEnabled,
+                isEnabled = uiState.isButtonEnabled,
                 isLastQuestion = uiState.isLastQuestion,
                 isFirstQuestion = uiState.isFirstQuestion,
                 onClickActionPrev = { onIntent(QuizSolveIntent.NavigateToPreviousQuestion) },
@@ -84,13 +84,13 @@ fun QuizSolveScreen(
                     Spacer(Modifier.height(36.dp))
                 }
                 item {
-                    QuizTitleSection(questionText = uiState.questionInfo.text)
+                    QuizTitleSection(questionText = uiState.currentQuiz?.content ?: "")
                 }
                 item {
                     Spacer(Modifier.height(24.dp))
                 }
                 item {
-                    when (uiState.questionInfo.type) {
+                    when (uiState.questionType) {
                         QuestionType.OX -> {
                             SelectOXSection(uiState = uiState, onIntent = onIntent)
                         }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
@@ -41,7 +41,7 @@ fun QuizSolveScreen(
     uiState: QuizSolveUiState,
     onIntent: (QuizSolveIntent) -> Unit
 ) {
-    val textRes = when {
+    val textRightRes = when {
         uiState.isWrongAnswer -> R.string.solve_btn_explanation
         uiState.isLastQuestion -> R.string.solve_btn_submit
         else -> R.string.solve_btn_next_text
@@ -200,12 +200,11 @@ fun SelectOXSection(
     uiState: QuizSolveUiState,
     onIntent: (QuizSolveIntent) -> Unit
 ) {
-    val oxOptions = uiState.mcq.options.ifEmpty {
-        listOf(
-            QuizOption(id = 0L, text = "O"),
-            QuizOption(id = 1L, text = "X")
-        )
-    }
+    val oxOptions = listOf(
+        QuizOption(id = 0L, text = "O"),
+        QuizOption(id = 1L, text = "X")
+    )
+
     Row(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
@@ -141,7 +141,7 @@ private fun QuizSolveBottomBar(
                     .padding(horizontal = 16.dp),
                 enabled = true,
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = if (isLastQuestion) primaryLight else yellow_200,
+                    containerColor = yellow_200,
                     contentColor = scrimLight,
                     disabledContainerColor = surfaceDimLight
                 ),
@@ -166,7 +166,7 @@ private fun QuizSolveBottomBar(
                 .padding(horizontal = 16.dp),
             enabled = isEnabled,
             colors = ButtonDefaults.buttonColors(
-                containerColor = yellow_200,
+                containerColor = if (isLastQuestion) yellow_200 else primaryLight,
                 contentColor = scrimLight,
                 disabledContainerColor = surfaceDimLight
             ),

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/QuizSolveScreen.kt
@@ -41,7 +41,7 @@ fun QuizSolveScreen(
     uiState: QuizSolveUiState,
     onIntent: (QuizSolveIntent) -> Unit
 ) {
-    val textRes = when {
+    val textRightRes = when {
         uiState.isWrongAnswer -> R.string.solve_btn_explanation
         uiState.isLastQuestion -> R.string.solve_btn_submit
         else -> R.string.solve_btn_next_text
@@ -115,24 +115,54 @@ fun QuizSolveScreen(
             }
 
             Spacer(modifier = Modifier.weight(1F))
-            QuizCafeButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                enabled = uiState.common.isButtonEnabled,
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = containerColor,
-                    contentColor = scrimLight,
-                    disabledContainerColor = surfaceDimLight
-                ),
-                onClick = onClickAction,
-                text = {
-                    Text(
-                        text = stringResource(textRes),
-                        style = quizCafeTypography().titleSmall
+            Row(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (!uiState.isFirstQuestion) {
+                    QuizCafeButton(
+                        modifier = Modifier
+                            .weight(1F)
+                            .padding(horizontal = 16.dp),
+                        enabled = true,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = wrongButtonColor,
+                            contentColor = scrimLight,
+                            disabledContainerColor = surfaceDimLight
+                        ),
+                        onClick = { onIntent(QuizSolveIntent.SubmitPrev) },
+                        text = {
+                            Text(
+                                text = stringResource(R.string.solve_btn_prev_text),
+                                style = quizCafeTypography().titleSmall
+                            )
+                        }
+                    )
+                } else {
+                    Spacer(
+                        modifier = Modifier
+                            .weight(1F)
+                            .padding(horizontal = 16.dp)
                     )
                 }
-            )
+                QuizCafeButton(
+                    modifier = Modifier
+                        .weight(1F)
+                        .padding(horizontal = 16.dp),
+                    enabled = uiState.common.isButtonEnabled,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = containerColor,
+                        contentColor = scrimLight,
+                        disabledContainerColor = surfaceDimLight
+                    ),
+                    onClick = onClickAction,
+                    text = {
+                        Text(
+                            text = stringResource(textRightRes),
+                            style = quizCafeTypography().titleSmall
+                        )
+                    }
+                )
+            }
         }
     }
 }
@@ -188,12 +218,11 @@ fun SelectOXSection(
     uiState: QuizSolveUiState,
     onIntent: (QuizSolveIntent) -> Unit
 ) {
-    val oxOptions = uiState.mcq.options.ifEmpty {
-        listOf(
-            QuizOption(id = 0L, text = "O"),
-            QuizOption(id = 1L, text = "X")
-        )
-    }
+    val oxOptions = listOf(
+        QuizOption(id = 0L, text = "O"),
+        QuizOption(id = 1L, text = "X")
+    )
+
     Row(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
@@ -18,6 +18,7 @@ sealed class QuizSolveIntent : BaseContract.ViewIntent {
     data class UpdatedSubjectiveAnswer(val answer: String) : QuizSolveIntent()
     data object SubmitAnswer : QuizSolveIntent()
     data object SubmitNext : QuizSolveIntent()
+    data object SubmitPrev : QuizSolveIntent()
     data object GradeQuizSuccess : QuizSolveIntent()
     data class SolveQuizSuccess(val quizBookGradeServerId: QuizBookGradeServerId) : QuizSolveIntent()
     data class GradeQuizError(val message: String?) : QuizSolveIntent()

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
@@ -13,23 +13,23 @@ sealed class QuizSolveIntent : BaseContract.ViewIntent {
     data class LoadQuizBookSuccess(val quizBook: QuizBook) : QuizSolveIntent()
     data class LoadQuizBookGradeSuccess(val quizBookGrade: QuizBookGrade) : QuizSolveIntent()
     data class SetQuizBookLocalId(val quizBookLocalId: QuizBookGradeLocalId) : QuizSolveIntent()
-    
+
     // 문제 선택
     data class SelectAnswer(val option: QuizOption) : QuizSolveIntent()
     data class UpdateSubjectiveAnswer(val answer: String) : QuizSolveIntent()
-    
+
     // 네비게이션
     data object NavigateBack : QuizSolveIntent()
     data object NavigateToNextQuestion : QuizSolveIntent()
     data object NavigateToPreviousQuestion : QuizSolveIntent()
     data object NavigateToResult : QuizSolveIntent()
-    
+
     // 문제 제출, 풀이
-    data object GradeQuizSuccess: QuizSolveIntent()
+    data object GradeQuizSuccess : QuizSolveIntent()
     data class GetQuizGradeSuccess(val quizGrade: QuizGrade?) : QuizSolveIntent()
     data class SubmitQuizBookSuccess(val quizBookGradeServerId: QuizBookGradeServerId) : QuizSolveIntent()
     data class HandleError(val message: String?) : QuizSolveIntent()
-    
+
     // 타이머
     data object UpdateTimer : QuizSolveIntent()
 }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
@@ -1,5 +1,6 @@
 package com.android.quizcafe.feature.quiz.solve.viewmodel
 
+import com.android.quizcafe.core.domain.model.quiz.QuizGrade
 import com.android.quizcafe.core.domain.model.quizbook.response.QuizBook
 import com.android.quizcafe.core.domain.model.solving.QuizBookGrade
 import com.android.quizcafe.core.domain.model.value.QuizBookGradeLocalId
@@ -19,7 +20,8 @@ sealed class QuizSolveIntent : BaseContract.ViewIntent {
     data object SubmitAnswer : QuizSolveIntent()
     data object SubmitNext : QuizSolveIntent()
     data object SubmitPrev : QuizSolveIntent()
-    data object GradeQuizSuccess : QuizSolveIntent()
+    data object GradeQuizBookSuccess : QuizSolveIntent()
+    data class GradeQuizSuccess(val quizGrade: QuizGrade?) : QuizSolveIntent()
     data class SolveQuizSuccess(val quizBookGradeServerId: QuizBookGradeServerId) : QuizSolveIntent()
     data class GradeQuizError(val message: String?) : QuizSolveIntent()
     data object ShowExplanation : QuizSolveIntent()

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
@@ -26,7 +26,7 @@ sealed class QuizSolveIntent : BaseContract.ViewIntent {
 
     // 문제 제출, 풀이
     data object GradeQuizSuccess : QuizSolveIntent()
-    data class GetQuizGradeSuccess(val quizGrade: QuizGrade?) : QuizSolveIntent()
+    data class GetQuizGradeSuccess(val quizGrade: QuizGrade) : QuizSolveIntent()
     data class SubmitQuizBookSuccess(val quizBookGradeServerId: QuizBookGradeServerId) : QuizSolveIntent()
     data class HandleError(val message: String?) : QuizSolveIntent()
 

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveIntent.kt
@@ -8,24 +8,28 @@ import com.android.quizcafe.core.domain.model.value.QuizBookGradeServerId
 import com.android.quizcafe.core.ui.base.BaseContract
 
 sealed class QuizSolveIntent : BaseContract.ViewIntent {
-    data class LoadQuizBook(val quizBookId: Long) : QuizSolveIntent()
-    data class SuccessGetQuizBook(val data: QuizBook) : QuizSolveIntent()
-    data class SuccessGetQuizBookGradeResult(val quizBookGrade: QuizBookGrade) : QuizSolveIntent()
-    data class GetQuizBookLocalId(val quizBookId: Long) : QuizSolveIntent()
-
-    data class GetQuizBookGradeResult(val quizBookLocalId: QuizBookGradeLocalId) : QuizSolveIntent()
-
-    data class SelectOption(val option: QuizOption) : QuizSolveIntent()
-    data class UpdatedSubjectiveAnswer(val answer: String) : QuizSolveIntent()
-    data object SubmitAnswer : QuizSolveIntent()
-    data object SubmitNext : QuizSolveIntent()
-    data object SubmitPrev : QuizSolveIntent()
-    data object GradeQuizBookSuccess : QuizSolveIntent()
-    data class GradeQuizSuccess(val quizGrade: QuizGrade?) : QuizSolveIntent()
-    data class SolveQuizSuccess(val quizBookGradeServerId: QuizBookGradeServerId) : QuizSolveIntent()
-    data class GradeQuizError(val message: String?) : QuizSolveIntent()
-    data object ShowExplanation : QuizSolveIntent()
-
-    data object OnBackClick : QuizSolveIntent()
-    data object TickTime : QuizSolveIntent()
+    // 초기화 작업
+    data class Initialize(val quizBookId: Long) : QuizSolveIntent()
+    data class LoadQuizBookSuccess(val quizBook: QuizBook) : QuizSolveIntent()
+    data class LoadQuizBookGradeSuccess(val quizBookGrade: QuizBookGrade) : QuizSolveIntent()
+    data class SetQuizBookLocalId(val quizBookLocalId: QuizBookGradeLocalId) : QuizSolveIntent()
+    
+    // 문제 선택
+    data class SelectAnswer(val option: QuizOption) : QuizSolveIntent()
+    data class UpdateSubjectiveAnswer(val answer: String) : QuizSolveIntent()
+    
+    // 네비게이션
+    data object NavigateBack : QuizSolveIntent()
+    data object NavigateToNextQuestion : QuizSolveIntent()
+    data object NavigateToPreviousQuestion : QuizSolveIntent()
+    data object NavigateToResult : QuizSolveIntent()
+    
+    // 문제 제출, 풀이
+    data object GradeQuizSuccess: QuizSolveIntent()
+    data class GetQuizGradeSuccess(val quizGrade: QuizGrade?) : QuizSolveIntent()
+    data class SubmitQuizBookSuccess(val quizBookGradeServerId: QuizBookGradeServerId) : QuizSolveIntent()
+    data class HandleError(val message: String?) : QuizSolveIntent()
+    
+    // 타이머
+    data object UpdateTimer : QuizSolveIntent()
 }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
@@ -18,17 +18,11 @@ data class QuizOption(
     val text: String
 )
 
-data class QuestionInfo(
-    val current: Int,
-    val total: Int,
-    val text: String,
-    val type: QuestionType
-)
-
 data class McqState(
-    val options: List<QuizOption>,
+    val options: List<QuizOption> = emptyList(),
     val selectedId: Long? = null,
     val selectedContent: String? = null,
+    val correctId: Long? = null,
     val correctContent: String? = null
 )
 
@@ -52,7 +46,8 @@ data class TimerState(
 )
 
 data class CommonState(
-    val isButtonEnabled: Boolean = false
+    val playMode: PlayMode = PlayMode.DEFAULT,
+    val currentIndex: Int = 0
 )
 
 data class QuizSolveUiState(
@@ -60,37 +55,26 @@ data class QuizSolveUiState(
     val errorMessage: String? = null,
     val quizBookLocalId: QuizBookGradeLocalId? = null,
     val quizBook: QuizBook? = null,
-    val playMode: PlayMode = PlayMode.DEFAULT,
-    val quizGrades: List<QuizGrade> = emptyList(),
-    val currentGrade: QuizGrade? = null,
-    val currentIndex: Int = 0,
-    val mcq: McqState = McqState(
-        options = listOf(
-            QuizOption(101L, "선택지 1"),
-            QuizOption(102L, "선택지 2"),
-            QuizOption(103L, "선택지 3"),
-            QuizOption(104L, "선택지 4")
-        )
-    ),
+    val quizGrades: List<QuizGrade>? = null,
     val subjective: SubjectiveState = SubjectiveState(),
+    val mcq: McqState = McqState(),
     val review: ReviewState = ReviewState(),
     val timer: TimerState = TimerState(),
-    val common: CommonState = CommonState()
+    val common: CommonState = CommonState(),
+    val currentGrade: QuizGrade? = null,
 ) : BaseContract.UiState {
-    val currentQuiz: Quiz?
-        get() = quizBook?.quizList?.getOrNull(currentIndex)
+    val isButtonEnabled: Boolean
+        get() = (subjective.answer != "" || mcq.selectedContent != null)
 
-    val questionInfo: QuestionInfo
-        get() = QuestionInfo(
-            current = currentIndex + 1,
-            total = quizBook?.totalQuizzes ?: 0,
-            text = currentQuiz?.content.orEmpty(),
-            type = when (currentQuiz?.questionType) {
-                "MCQ" -> QuestionType.MULTIPLE_CHOICE
-                "OX" -> QuestionType.OX
-                else -> QuestionType.SUBJECTIVE
-            }
-        )
+    val currentQuiz: Quiz?
+        get() = quizBook?.quizList?.getOrNull(common.currentIndex)
+
+    val questionType: QuestionType
+        get() = when (currentQuiz?.questionType) {
+            "MCQ" -> QuestionType.MULTIPLE_CHOICE
+            "OX" -> QuestionType.OX
+            else -> QuestionType.SUBJECTIVE
+        }
     val optionList: List<QuizOption>
         get() = currentQuiz?.mcqOption
             ?.map { QuizOption(id = it.quizId.value, text = it.optionContent) }
@@ -98,38 +82,11 @@ data class QuizSolveUiState(
                 QuizOption(0L, "O"),
                 QuizOption(1L, "X")
             )
-
-
-
-    private val currentPhase: AnswerPhase
-        get() = if (currentGrade != null) AnswerPhase.REVIEW else AnswerPhase.ANSWERING
-
-    fun getOptionState(opt: QuizOption): AnswerState = when (currentPhase) {
-
-        AnswerPhase.ANSWERING -> {
-            if (opt.text == mcq.selectedContent) {
-                AnswerState.SELECTED
-            } else {
-                AnswerState.DEFAULT
-            }
-        }
-
-        AnswerPhase.REVIEW -> currentGrade?.let { gr ->
-            Log.d("test1234",mcq.correctContent.toString())
-            when {
-                gr.isCorrect && opt.text == gr.userAnswer -> AnswerState.CORRECT
-                !gr.isCorrect && opt.text == gr.userAnswer -> AnswerState.INCORRECT
-                opt.text == mcq.correctContent ->{
-                    AnswerState.CORRECT}
-                else -> AnswerState.DEFAULT
-            }
-        } ?: AnswerState.DEFAULT
-    }
     val isFirstQuestion: Boolean
-        get() = questionInfo.current == 1
+        get() = common.currentIndex == 0
 
     val isLastQuestion: Boolean
-        get() = questionInfo.current == questionInfo.total
+        get() = (common.currentIndex + 1) == (quizBook?.totalQuizzes)
 
     val isWrongAnswer: Boolean
         get() = !review.showExplanation && (currentGrade?.isCorrect == false || optionList.any { getOptionState(it) == AnswerState.INCORRECT })
@@ -140,4 +97,96 @@ data class QuizSolveUiState(
         val s = seconds % 60
         return String.format(Locale.KOREA, "%02d:%02d", m, s)
     }
+
+    private val currentPhase: AnswerPhase
+        get() = if (currentGrade != null) AnswerPhase.REVIEW else AnswerPhase.ANSWERING
+
+
+    fun getOptionState(opt: QuizOption): AnswerState = when (currentPhase) {
+        AnswerPhase.ANSWERING -> {
+            if (opt.text == mcq.selectedContent) {
+                AnswerState.SELECTED
+            } else {
+                AnswerState.DEFAULT
+            }
+        }
+
+        AnswerPhase.REVIEW -> currentGrade?.let { gr ->
+            Log.d("test1234", mcq.correctContent.toString())
+            when {
+                gr.isCorrect && opt.text == gr.userAnswer -> AnswerState.CORRECT
+                !gr.isCorrect && opt.text == gr.userAnswer -> AnswerState.INCORRECT
+                opt.text == mcq.correctContent -> {
+                    AnswerState.CORRECT
+                }
+
+                else -> AnswerState.DEFAULT
+            }
+        } ?: AnswerState.DEFAULT
+    }
 }
+
+fun QuizSolveUiState.previousQuestionReset(): QuizSolveUiState {
+    val newIndex = (common.currentIndex - 1).coerceAtLeast(0)
+    return copy(
+        common = common.copy(
+            currentIndex = newIndex
+        ),
+        mcq = McqState(),
+        subjective = SubjectiveState(),
+        review = ReviewState()
+    )
+}
+
+fun QuizSolveUiState.applyFetchedGrade(grade: QuizGrade): QuizSolveUiState =
+    when (common.playMode) {
+        PlayMode.DEFAULT -> copy(
+            subjective = subjective.copy(answer = grade.userAnswer),
+            mcq = mcq.copy(selectedContent = grade.userAnswer)
+        )
+
+        PlayMode.REVIEW_MODE -> if (review.showExplanation) {
+            copy(
+                currentGrade = null,
+                common = common.copy(
+                    currentIndex = common.currentIndex + 1
+                ),
+                subjective = SubjectiveState(),
+                mcq = McqState(),
+                review = ReviewState()
+            )
+        } else {
+            val correctContent = if (questionType == QuestionType.MULTIPLE_CHOICE)
+                optionList[(currentQuiz?.answer ?: "0").toInt() - 1].text
+            else
+                currentQuiz?.answer
+            copy(
+                currentGrade = grade,
+                subjective = subjective.copy(
+                    answer = grade.userAnswer,
+                    correctAnswer = currentQuiz?.answer
+                ),
+                mcq = mcq.copy(
+                    selectedContent = grade.userAnswer,
+                    correctContent = correctContent
+                ),
+                review = review.copy(
+                    answerState = if (grade.isCorrect) AnswerState.CORRECT else AnswerState.INCORRECT,
+                    showExplanation = true,
+                    explanation = currentQuiz?.explanation.orEmpty()
+                )
+            )
+        }
+    }
+
+
+fun QuizSolveUiState.onLocalSaveSuccess(): QuizSolveUiState =
+    if (!isLastQuestion && common.playMode == PlayMode.DEFAULT) {
+        copy(
+            common = common.copy(
+                currentIndex = common.currentIndex + 1
+            ),
+            subjective = SubjectiveState(),
+            mcq = McqState()
+        )
+    } else this

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
@@ -1,5 +1,6 @@
 package com.android.quizcafe.feature.quiz.solve.viewmodel
 
+import android.util.Log
 import com.android.quizcafe.core.domain.model.quiz.Quiz
 import com.android.quizcafe.core.domain.model.quiz.QuizGrade
 import com.android.quizcafe.core.domain.model.quizbook.response.QuizBook
@@ -9,7 +10,7 @@ import com.android.quizcafe.feature.quiz.solve.component.AnswerState
 import java.util.Locale
 
 enum class QuestionType { OX, MULTIPLE_CHOICE, SUBJECTIVE }
-enum class PlayMode { TIME_ATTACK, NO_TIME_ATTACK }
+enum class PlayMode { DEFAULT, REVIEW_MODE }
 enum class AnswerPhase { ANSWERING, REVIEW }
 
 data class QuizOption(
@@ -28,7 +29,7 @@ data class McqState(
     val options: List<QuizOption>,
     val selectedId: Long? = null,
     val selectedContent: String? = null,
-    val correctId: Long? = null
+    val correctContent: String? = null
 )
 
 data class SubjectiveState(
@@ -46,7 +47,6 @@ data class ReviewState(
 )
 
 data class TimerState(
-    val playMode: PlayMode = PlayMode.NO_TIME_ATTACK,
     val remainingSeconds: Int = 600,
     val elapsedSeconds: Int = 0
 )
@@ -60,7 +60,9 @@ data class QuizSolveUiState(
     val errorMessage: String? = null,
     val quizBookLocalId: QuizBookGradeLocalId? = null,
     val quizBook: QuizBook? = null,
+    val playMode: PlayMode = PlayMode.DEFAULT,
     val quizGrades: List<QuizGrade> = emptyList(),
+    val currentGrade: QuizGrade? = null,
     val currentIndex: Int = 0,
     val mcq: McqState = McqState(
         options = listOf(
@@ -97,24 +99,28 @@ data class QuizSolveUiState(
                 QuizOption(1L, "X")
             )
 
-    private val currentGrade: QuizGrade?
-        get() = quizGrades.getOrNull(currentIndex)
+
 
     private val currentPhase: AnswerPhase
         get() = if (currentGrade != null) AnswerPhase.REVIEW else AnswerPhase.ANSWERING
 
     fun getOptionState(opt: QuizOption): AnswerState = when (currentPhase) {
-        AnswerPhase.ANSWERING ->
+
+        AnswerPhase.ANSWERING -> {
             if (opt.text == mcq.selectedContent) {
                 AnswerState.SELECTED
             } else {
                 AnswerState.DEFAULT
             }
+        }
 
         AnswerPhase.REVIEW -> currentGrade?.let { gr ->
+            Log.d("test1234",mcq.correctContent.toString())
             when {
-                gr.isCorrect && opt.id.toString() == gr.userAnswer -> AnswerState.CORRECT
-                !gr.isCorrect && opt.id.toString() == gr.userAnswer -> AnswerState.INCORRECT
+                gr.isCorrect && opt.text == gr.userAnswer -> AnswerState.CORRECT
+                !gr.isCorrect && opt.text == gr.userAnswer -> AnswerState.INCORRECT
+                opt.text == mcq.correctContent ->{
+                    AnswerState.CORRECT}
                 else -> AnswerState.DEFAULT
             }
         } ?: AnswerState.DEFAULT
@@ -129,7 +135,7 @@ data class QuizSolveUiState(
         get() = !review.showExplanation && (currentGrade?.isCorrect == false || optionList.any { getOptionState(it) == AnswerState.INCORRECT })
 
     fun getTimeText(): String {
-        val seconds = if (timer.playMode == PlayMode.TIME_ATTACK) timer.remainingSeconds else timer.elapsedSeconds
+        val seconds = timer.elapsedSeconds
         val m = seconds / 60
         val s = seconds % 60
         return String.format(Locale.KOREA, "%02d:%02d", m, s)

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
@@ -119,6 +119,8 @@ data class QuizSolveUiState(
             }
         } ?: AnswerState.DEFAULT
     }
+    val isFirstQuestion: Boolean
+        get() = questionInfo.current == 1
 
     val isLastQuestion: Boolean
         get() = questionInfo.current == questionInfo.total

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
@@ -101,7 +101,6 @@ data class QuizSolveUiState(
     private val currentPhase: AnswerPhase
         get() = if (currentGrade != null) AnswerPhase.REVIEW else AnswerPhase.ANSWERING
 
-
     fun getOptionState(opt: QuizOption): AnswerState = when (currentPhase) {
         AnswerPhase.ANSWERING -> {
             if (opt.text == mcq.selectedContent) {
@@ -156,10 +155,11 @@ fun QuizSolveUiState.applyFetchedGrade(grade: QuizGrade): QuizSolveUiState =
                 review = ReviewState()
             )
         } else {
-            val correctContent = if (questionType == QuestionType.MULTIPLE_CHOICE)
+            val correctContent = if (questionType == QuestionType.MULTIPLE_CHOICE) {
                 optionList[(currentQuiz?.answer ?: "0").toInt() - 1].text
-            else
+            } else {
                 currentQuiz?.answer
+            }
             copy(
                 currentGrade = grade,
                 subjective = subjective.copy(
@@ -179,7 +179,6 @@ fun QuizSolveUiState.applyFetchedGrade(grade: QuizGrade): QuizSolveUiState =
         }
     }
 
-
 fun QuizSolveUiState.onLocalSaveSuccess(): QuizSolveUiState =
     if (!isLastQuestion && common.playMode == PlayMode.DEFAULT) {
         copy(
@@ -189,4 +188,6 @@ fun QuizSolveUiState.onLocalSaveSuccess(): QuizSolveUiState =
             subjective = SubjectiveState(),
             mcq = McqState()
         )
-    } else this
+    } else {
+        this
+    }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveUiState.kt
@@ -133,6 +133,8 @@ data class QuizSolveUiState(
             AnswerPhase.REVIEW ->
                 if (currentGrade?.isCorrect == true) AnswerState.CORRECT else AnswerState.INCORRECT
         }
+    val isFirstQuestion: Boolean
+        get() = questionInfo.current == 1
 
     val isLastQuestion: Boolean
         get() = questionInfo.current == questionInfo.total

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -186,7 +186,6 @@ class QuizSolveViewModel @Inject constructor(
             is QuizSolveIntent.GetQuizGradeSuccess ->
                 currentState.applyFetchedGrade(intent.quizGrade)
 
-
             QuizSolveIntent.GradeQuizSuccess -> {
                 currentState.onLocalSaveSuccess()
             }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -58,7 +58,6 @@ class QuizSolveViewModel @Inject constructor(
                 getQuizBookGradeResult(intent.quizBookLocalId)
             }
 
-
             is QuizSolveIntent.SubmitQuizBookSuccess -> {
                 emitEffect(QuizSolveEffect.NavigateToQuizBookSolvingResult(intent.quizBookGradeServerId))
             }
@@ -78,7 +77,7 @@ class QuizSolveViewModel @Inject constructor(
                     }
                     else -> {
                         saveQuizToLocal()
-                        if(currentState.isLastQuestion){
+                        if (currentState.isLastQuestion) {
                             submitQuizAnswer()
                         }
                     }
@@ -86,7 +85,7 @@ class QuizSolveViewModel @Inject constructor(
             }
 
             QuizSolveIntent.NavigateToPreviousQuestion -> {
-               getQuizAnswer()
+                getQuizAnswer()
             }
             is QuizSolveIntent.GradeQuizSuccess -> {
                 val currentState = state.value
@@ -105,7 +104,6 @@ class QuizSolveViewModel @Inject constructor(
             is QuizSolveIntent.LoadQuizBookSuccess,
             is QuizSolveIntent.LoadQuizBookGradeSuccess,
             QuizSolveIntent.UpdateTimer -> {
-
             }
 
             is QuizSolveIntent.GetQuizGradeSuccess -> {
@@ -149,8 +147,9 @@ class QuizSolveViewModel @Inject constructor(
                         isLoading = true,
                         errorMessage = null
                     )
-                } else
+                } else {
                     currentState.copy(isLoading = true, errorMessage = null)
+                }
             }
 
             is QuizSolveIntent.LoadQuizBookSuccess -> {
@@ -178,12 +177,10 @@ class QuizSolveViewModel @Inject constructor(
                 }
             }
 
-
             is QuizSolveIntent.GetQuizGradeSuccess ->
                 intent.quizGrade
                     ?.let { currentState.applyFetchedGrade(it) }
                     ?: currentState
-
 
             QuizSolveIntent.GradeQuizSuccess -> {
                 currentState.onLocalSaveSuccess()

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -141,16 +141,25 @@ class QuizSolveViewModel @Inject constructor(
                     quizGrades = intent.quizBookGrade.quizGrades
                 )
 
+            is QuizSolveIntent.SubmitPrev ->
+                currentState.copy(
+                    currentIndex = currentState.currentIndex - 1,
+                )
             QuizSolveIntent.GradeQuizSuccess -> {
                 if (!currentState.isLastQuestion) {
                     currentState.copy(
                         currentIndex = currentState.currentIndex + 1,
-                        common = CommonState(false)
+                        common = CommonState(false),
+                        subjective = currentState.subjective.copy(
+                            answer = ""
+                        ) ,
+                        mcq = currentState.mcq.copy(
+                            selectedContent = ""
+                        )
                     )
                 } else
                     currentState
             }
-
             else -> currentState
         }
     }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -1,7 +1,6 @@
 package com.android.quizcafe.feature.quiz.solve.viewmodel
 
 import android.util.Log
-import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.viewModelScope
 import com.android.quizcafe.core.domain.model.Resource
 import com.android.quizcafe.core.domain.model.value.QuizBookGradeLocalId
@@ -13,11 +12,12 @@ import com.android.quizcafe.core.domain.usecase.solving.GetQuizGradeUseCase
 import com.android.quizcafe.core.domain.usecase.solving.GradeQuizUseCase
 import com.android.quizcafe.core.domain.usecase.solving.SolveQuizBookUseCase
 import com.android.quizcafe.core.ui.base.BaseViewModel
+import com.android.quizcafe.feature.quiz.solve.component.AnswerState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.abs
 
 @HiltViewModel
 class QuizSolveViewModel @Inject constructor(
@@ -34,76 +34,83 @@ class QuizSolveViewModel @Inject constructor(
         viewModelScope.launch {
             while (true) {
                 delay(1_000L)
-                sendIntent(QuizSolveIntent.TickTime)
+                sendIntent(QuizSolveIntent.UpdateTimer)
             }
         }
     }
 
     override suspend fun handleIntent(intent: QuizSolveIntent) {
         when (intent) {
-            QuizSolveIntent.OnBackClick -> {
+            QuizSolveIntent.NavigateBack -> {
                 emitEffect(QuizSolveEffect.NavigatePopBack)
             }
 
-            is QuizSolveIntent.LoadQuizBook -> {
-                getQuizBook(intent.quizBookId)
+            QuizSolveIntent.NavigateToResult -> {
+                // This will be handled by SubmitQuizBookSuccess
             }
 
-            is QuizSolveIntent.GetQuizBookLocalId -> {
+            // 초기화
+            is QuizSolveIntent.Initialize -> {
+                loadQuizBook(abs(intent.quizBookId))
                 getQuizBookLocalId(intent.quizBookId)
             }
 
-            is QuizSolveIntent.GetQuizBookGradeResult -> {
+            is QuizSolveIntent.SetQuizBookLocalId -> {
                 getQuizBookGradeResult(intent.quizBookLocalId)
             }
 
-            is QuizSolveIntent.SubmitNext -> {
-                saveQuizToLocal()
-            }
 
-            is QuizSolveIntent.SubmitAnswer -> {
-                submitQuizAnswer()
-            }
-
-            is QuizSolveIntent.SolveQuizSuccess -> {
+            is QuizSolveIntent.SubmitQuizBookSuccess -> {
                 emitEffect(QuizSolveEffect.NavigateToQuizBookSolvingResult(intent.quizBookGradeServerId))
             }
 
-            is QuizSolveIntent.GradeQuizError -> {
+            is QuizSolveIntent.HandleError -> {
                 emitEffect(QuizSolveEffect.ShowErrorDialog(intent.message ?: ""))
             }
-            is QuizSolveIntent.SubmitPrev -> {
-                getQuizAnswer()
+
+            QuizSolveIntent.NavigateToNextQuestion -> {
+                val currentState = state.value
+                saveQuizToLocal()
+                if (currentState.isLastQuestion) {
+                    submitQuizAnswer()
+                }
             }
-            QuizSolveIntent.GradeQuizBookSuccess -> {
-                getQuizAnswer()
+
+            QuizSolveIntent.NavigateToPreviousQuestion -> {
+               getQuizAnswer()
             }
-            else -> Unit
+            is QuizSolveIntent.GradeQuizSuccess -> {
+                val currentState = state.value
+                if(!currentState.isLastQuestion){
+                    getQuizAnswer()
+                }
+            }
+            is QuizSolveIntent.SelectAnswer,
+            is QuizSolveIntent.UpdateSubjectiveAnswer,
+            is QuizSolveIntent.LoadQuizBookSuccess,
+            is QuizSolveIntent.LoadQuizBookGradeSuccess,
+            QuizSolveIntent.UpdateTimer -> {
+
+            }
+
+            is QuizSolveIntent.GetQuizGradeSuccess -> {
+            }
         }
     }
 
     override fun reduce(currentState: QuizSolveUiState, intent: QuizSolveIntent): QuizSolveUiState {
         return when (intent) {
-            QuizSolveIntent.TickTime -> {
+            // 타이머
+            QuizSolveIntent.UpdateTimer -> {
                 val timer = currentState.timer
-                when (timer.playMode) {
-                    PlayMode.TIME_ATTACK ->
-                        currentState.copy(
-                            timer = timer.copy(
-                                remainingSeconds = (timer.remainingSeconds - 1).coerceAtLeast(0)
-                            )
-                        )
-
-                    PlayMode.NO_TIME_ATTACK ->
-                        currentState.copy(
-                            timer = timer.copy(
-                                elapsedSeconds = timer.elapsedSeconds + 1
-                            )
-                        )
-                }
+                currentState.copy(
+                    timer = timer.copy(
+                        elapsedSeconds = timer.elapsedSeconds + 1
+                    )
+                )
             }
 
-            is QuizSolveIntent.SelectOption ->
+            is QuizSolveIntent.SelectAnswer ->
                 currentState.copy(
                     mcq = currentState.mcq.copy(
                         selectedId = intent.option.id,
@@ -114,7 +121,7 @@ class QuizSolveViewModel @Inject constructor(
                     )
                 )
 
-            is QuizSolveIntent.UpdatedSubjectiveAnswer ->
+            is QuizSolveIntent.UpdateSubjectiveAnswer ->
                 currentState.copy(
                     subjective = currentState.subjective.copy(
                         answer = intent.answer
@@ -124,55 +131,138 @@ class QuizSolveViewModel @Inject constructor(
                     )
                 )
 
-            // ─── 4) 해설보기 토글 ─────────────────────────────────────────
-            QuizSolveIntent.ShowExplanation ->
-                currentState.copy(
-                    review = currentState.review.copy(
-                        showExplanation = true
+            is QuizSolveIntent.Initialize -> {
+                if (intent.quizBookId < 0) {
+                    currentState.copy(
+                        playMode = PlayMode.REVIEW_MODE,
+                        isLoading = true,
+                        errorMessage = null
                     )
-                )
+                } else
+                    currentState.copy(isLoading = true, errorMessage = null)
+            }
 
-            is QuizSolveIntent.LoadQuizBook -> currentState.copy(isLoading = true, errorMessage = null)
-            is QuizSolveIntent.SuccessGetQuizBook -> {
+            is QuizSolveIntent.LoadQuizBookSuccess -> {
                 currentState.copy(
-                    quizBook = intent.data,
+                    quizBook = intent.quizBook,
                     isLoading = false
                 )
             }
 
-            is QuizSolveIntent.GetQuizBookGradeResult ->
+            is QuizSolveIntent.SetQuizBookLocalId ->
                 currentState.copy(
                     quizBookLocalId = intent.quizBookLocalId
                 )
 
-            is QuizSolveIntent.SuccessGetQuizBookGradeResult ->
+            is QuizSolveIntent.LoadQuizBookGradeSuccess ->
                 currentState.copy(
                     quizGrades = intent.quizBookGrade.quizGrades
                 )
 
-            is QuizSolveIntent.SubmitPrev ->
-                currentState.copy(
-                    currentIndex = currentState.currentIndex - 1,
-                )
-             is QuizSolveIntent.GradeQuizSuccess -> {
-                 val quizGrade = intent.quizGrade
-                 if(quizGrade == null){
-                     currentState
-                 }
-                 else {
-                     currentState.copy(
-                         common = CommonState(true),
-                         subjective = currentState.subjective.copy(
-                             answer = quizGrade.userAnswer
-                         ),
-                         mcq = currentState.mcq.copy(
-                             selectedContent = quizGrade.userAnswer
-                         )
-                     )
-                 }
-             }
-            QuizSolveIntent.GradeQuizBookSuccess -> {
-                if (!currentState.isLastQuestion) {
+            QuizSolveIntent.NavigateToPreviousQuestion -> {
+                if (currentState.currentIndex > 0) {
+                    if (currentState.playMode == PlayMode.DEFAULT) {
+                        // DEFAULT_MODE에서는 이전 문제로 이동하고 상태 초기화
+                        // TODO: 확장함수로 분리
+                        currentState.copy(
+                            currentIndex = currentState.currentIndex - 1,
+                            common = CommonState(false),
+                            subjective = currentState.subjective.copy(
+                                answer = ""
+                            ),
+                            mcq = currentState.mcq.copy(
+                                selectedContent = ""
+                            ),
+                            review = ReviewState()
+                        )
+                    } else {
+                        currentState.copy(
+                            currentIndex = currentState.currentIndex - 1,
+                        )
+                    }
+                } else {
+                    // 첫 번째 문제에서는 이동하지 않음
+                    currentState
+                }
+            }
+
+
+            is QuizSolveIntent.GetQuizGradeSuccess -> {
+                val quizGrade = intent.quizGrade
+                if (quizGrade == null) {
+                    currentState
+                } else {
+                    when (currentState.playMode) {
+                        PlayMode.DEFAULT -> {
+                            currentState.copy(
+                                common = CommonState(true),
+                                subjective = currentState.subjective.copy(
+                                    answer = quizGrade.userAnswer
+                                ),
+                                mcq = currentState.mcq.copy(
+                                    selectedContent = quizGrade.userAnswer
+                                )
+                            )
+                        }
+
+                        PlayMode.REVIEW_MODE -> {
+                            if (currentState.review.showExplanation) {
+                                // 다음 문제 클릭했을때 reduce 로직
+                                if(currentState.currentGrade != null) {
+                                    currentState.copy(
+                                        currentGrade = null,
+                                        currentIndex = currentState.currentIndex + 1,
+                                        subjective = currentState.subjective.copy(
+                                            answer = ""
+                                        ),
+                                        mcq = currentState.mcq.copy(
+                                            selectedContent = ""
+                                        ),
+                                        review = ReviewState()
+                                    )
+                                }else{
+                                    // 이전 문제 클릭했을때 reduce 로직
+                                    currentState.copy(
+                                        currentGrade = quizGrade,
+                                        subjective = currentState.subjective.copy(
+                                            answer = quizGrade.userAnswer
+                                        ),
+                                        mcq = currentState.mcq.copy(
+                                            selectedContent = quizGrade.userAnswer
+                                        ),
+                                        review = currentState.review.copy(
+                                            answerState = if (quizGrade.isCorrect) AnswerState.CORRECT else AnswerState.INCORRECT,
+                                            showExplanation = true,
+                                            explanation = currentState.currentQuiz?.explanation ?: ""
+                                        )
+                                    )
+                                }
+                            } else {
+                                currentState.copy(
+                                    currentGrade = quizGrade,
+                                    subjective = currentState.subjective.copy(
+                                        answer = quizGrade.userAnswer,
+                                        correctAnswer = currentState.currentQuiz?.answer
+                                    ),
+                                    mcq = currentState.mcq.copy(
+                                        selectedContent = quizGrade.userAnswer,
+                                        correctContent = if(currentState.questionInfo.type == QuestionType.MULTIPLE_CHOICE)currentState.optionList[(currentState.currentQuiz?.answer ?: "0").toInt()-1].text else currentState.currentQuiz?.answer
+                                    ),
+                                    review = currentState.review.copy(
+                                        answerState = if (quizGrade.isCorrect) AnswerState.CORRECT else AnswerState.INCORRECT,
+                                        showExplanation = true,
+                                        explanation = currentState.currentQuiz?.explanation ?: ""
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+
+            QuizSolveIntent.GradeQuizSuccess -> {
+                if (!currentState.isLastQuestion && currentState.playMode == PlayMode.DEFAULT) {
                     currentState.copy(
                         currentIndex = currentState.currentIndex + 1,
                         common = CommonState(false),
@@ -183,22 +273,26 @@ class QuizSolveViewModel @Inject constructor(
                             selectedContent = ""
                         )
                     )
-
                 } else
                     currentState
             }
-            else -> currentState
+            is QuizSolveIntent.HandleError,
+            QuizSolveIntent.NavigateBack,
+            QuizSolveIntent.NavigateToNextQuestion,
+            QuizSolveIntent.NavigateToResult,
+            is QuizSolveIntent.SubmitQuizBookSuccess -> currentState
         }
     }
 
-    private suspend fun getQuizBook(id: Long) {
+    // MARK: - Private Methods
+    private suspend fun loadQuizBook(id: Long) {
         getQuizBookUseCase(
             QuizBookId(id)
         ).collect {
             when (it) {
                 is Resource.Success -> {
                     Log.d("getQuizBook", "${it.data.quizList}")
-                    sendIntent(QuizSolveIntent.SuccessGetQuizBook(it.data))
+                    sendIntent(QuizSolveIntent.LoadQuizBookSuccess(it.data))
                 }
 
                 is Resource.Loading -> {
@@ -214,13 +308,12 @@ class QuizSolveViewModel @Inject constructor(
 
     private suspend fun getQuizBookLocalId(id: Long) {
         getQuizBookLocalIdUseCase(
-            QuizBookId(id)
+            QuizBookId(abs(id))
         ).collect {
             when (it) {
                 is Resource.Success -> {
                     Log.d("getQuizBookLocalId", "Get QuizBookDetail Success")
-                    // 로컬 id를 uiState에 저장 reduce
-                    sendIntent(QuizSolveIntent.GetQuizBookGradeResult(it.data))
+                    sendIntent(QuizSolveIntent.SetQuizBookLocalId(it.data))
                 }
 
                 is Resource.Loading -> {
@@ -241,7 +334,7 @@ class QuizSolveViewModel @Inject constructor(
             when (it) {
                 is Resource.Success -> {
                     Log.d("getQuizBookGradeUseCase", "Get QuizBookDetail Success")
-                    sendIntent(QuizSolveIntent.SuccessGetQuizBookGradeResult(it.data))
+                    sendIntent(QuizSolveIntent.LoadQuizBookGradeSuccess(it.data))
                 }
 
                 is Resource.Loading -> {
@@ -264,7 +357,6 @@ class QuizSolveViewModel @Inject constructor(
             else -> uiState.mcq.selectedContent
         }
         if (quiz != null && localId != null && userAnswer != null) {
-            println(localId)
             gradeQuizUseCase(
                 quiz,
                 localId,
@@ -272,10 +364,8 @@ class QuizSolveViewModel @Inject constructor(
             ).collect {
                 when (it) {
                     is Resource.Success -> {
-                        sendIntent(QuizSolveIntent.GradeQuizBookSuccess)
-                        if(uiState.isLastQuestion){
-                            sendIntent(QuizSolveIntent.SubmitAnswer)
-                        }
+                        // 답안 저장 성공 후 상태 업데이트
+                        sendIntent(QuizSolveIntent.GradeQuizSuccess)
                         Log.d("getQuizBookGradeUseCase", "Get QuizBookDetail Success")
                     }
 
@@ -285,12 +375,12 @@ class QuizSolveViewModel @Inject constructor(
 
                     is Resource.Failure -> {
                         Log.d("getQuizBookGradeUseCase", it.errorMessage)
-                        sendIntent(QuizSolveIntent.GradeQuizError(it.errorMessage))
+                        sendIntent(QuizSolveIntent.HandleError(it.errorMessage))
                     }
                 }
             }
         } else {
-            sendIntent(QuizSolveIntent.GradeQuizError("문제 발생"))
+            sendIntent(QuizSolveIntent.HandleError("문제 발생"))
         }
     }
 
@@ -304,7 +394,7 @@ class QuizSolveViewModel @Inject constructor(
             ).collect {
                 when (it) {
                     is Resource.Success -> {
-                        sendIntent(QuizSolveIntent.SolveQuizSuccess(it.data))
+                        sendIntent(QuizSolveIntent.SubmitQuizBookSuccess(it.data))
                         Log.d("solveQuizBookUseCase", "채점 Success")
                     }
 
@@ -314,17 +404,19 @@ class QuizSolveViewModel @Inject constructor(
 
                     is Resource.Failure -> {
                         Log.d("solveQuizBookUseCase", it.errorMessage)
-                        sendIntent(QuizSolveIntent.GradeQuizError(it.errorMessage))
+                        sendIntent(QuizSolveIntent.HandleError(it.errorMessage))
                     }
                 }
             }
         } else {
-            sendIntent(QuizSolveIntent.GradeQuizError("문제 발생"))
+            sendIntent(QuizSolveIntent.HandleError("문제 발생"))
         }
     }
+
     private suspend fun getQuizAnswer() {
-        val localId = state.value.quizBookLocalId
-        val quizId = state.value.currentQuiz?.id
+        val currentState = state.value
+        val localId = currentState.quizBookLocalId
+        val quizId = currentState.currentQuiz?.id
         if (localId != null && quizId != null) {
             getQuizGradeUseCase(
                 quizBookGradeLocalId = localId,
@@ -332,7 +424,7 @@ class QuizSolveViewModel @Inject constructor(
             ).collect {
                 when (it) {
                     is Resource.Success -> {
-                        sendIntent(QuizSolveIntent.GradeQuizSuccess(it.data))
+                        sendIntent(QuizSolveIntent.GetQuizGradeSuccess(it.data))
                         Log.d("getQuizGradeUseCase", "Success")
                     }
 
@@ -342,12 +434,12 @@ class QuizSolveViewModel @Inject constructor(
 
                     is Resource.Failure -> {
                         Log.d("getQuizGradeUseCase", it.errorMessage)
-                        sendIntent(QuizSolveIntent.GradeQuizError(it.errorMessage))
+                        sendIntent(QuizSolveIntent.HandleError(it.errorMessage))
                     }
                 }
             }
         } else {
-            sendIntent(QuizSolveIntent.GradeQuizError("문제 발생"))
+            sendIntent(QuizSolveIntent.HandleError("문제 발생"))
         }
     }
 }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -139,10 +139,20 @@ class QuizSolveViewModel @Inject constructor(
                 currentState.copy(
                     quizGrades = intent.quizBookGrade.quizGrades
                 )
+            is QuizSolveIntent.SubmitPrev ->
+                currentState.copy(
+                    currentIndex = currentState.currentIndex - 1,
+                )
             QuizSolveIntent.GradeQuizSuccess -> {
                 currentState.copy(
                     currentIndex = currentState.currentIndex + 1,
-                    common = CommonState(false)
+                    common = CommonState(false),
+                    subjective = currentState.subjective.copy(
+                        answer = ""
+                    ) ,
+                    mcq = currentState.mcq.copy(
+                        selectedContent = ""
+                    )
                 )
             }
             else -> currentState

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -72,9 +72,11 @@ class QuizSolveViewModel @Inject constructor(
                     currentState.common.playMode == PlayMode.REVIEW_MODE && !currentState.review.showExplanation -> {
                         saveQuizToLocal()
                     }
+
                     currentState.common.playMode == PlayMode.REVIEW_MODE && currentState.isLastQuestion -> {
                         submitQuizAnswer()
                     }
+
                     else -> {
                         saveQuizToLocal()
                         if (currentState.isLastQuestion) {
@@ -87,18 +89,22 @@ class QuizSolveViewModel @Inject constructor(
             QuizSolveIntent.NavigateToPreviousQuestion -> {
                 getQuizAnswer()
             }
+
             is QuizSolveIntent.GradeQuizSuccess -> {
                 val currentState = state.value
                 when {
                     currentState.common.playMode == PlayMode.REVIEW_MODE -> {
                         getQuizAnswer()
                     }
+
                     !currentState.isLastQuestion && currentState.common.playMode == PlayMode.DEFAULT -> {
                         getQuizAnswer()
                     }
+
                     else -> Unit
                 }
             }
+
             is QuizSolveIntent.SelectAnswer,
             is QuizSolveIntent.UpdateSubjectiveAnswer,
             is QuizSolveIntent.LoadQuizBookSuccess,
@@ -178,13 +184,13 @@ class QuizSolveViewModel @Inject constructor(
             }
 
             is QuizSolveIntent.GetQuizGradeSuccess ->
-                intent.quizGrade
-                    ?.let { currentState.applyFetchedGrade(it) }
-                    ?: currentState
+                currentState.applyFetchedGrade(intent.quizGrade)
+
 
             QuizSolveIntent.GradeQuizSuccess -> {
                 currentState.onLocalSaveSuccess()
             }
+
             is QuizSolveIntent.HandleError,
             QuizSolveIntent.NavigateBack,
             QuizSolveIntent.NavigateToNextQuestion,

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -1,6 +1,7 @@
 package com.android.quizcafe.feature.quiz.solve.viewmodel
 
 import android.util.Log
+import androidx.compose.runtime.snapshotFlow
 import androidx.lifecycle.viewModelScope
 import com.android.quizcafe.core.domain.model.Resource
 import com.android.quizcafe.core.domain.model.value.QuizBookGradeLocalId
@@ -8,11 +9,13 @@ import com.android.quizcafe.core.domain.model.value.QuizBookId
 import com.android.quizcafe.core.domain.usecase.quizbook.GetQuizBookUseCase
 import com.android.quizcafe.core.domain.usecase.solving.GetQuizBookGradeUseCase
 import com.android.quizcafe.core.domain.usecase.solving.GetQuizBookLocalIdUseCase
+import com.android.quizcafe.core.domain.usecase.solving.GetQuizGradeUseCase
 import com.android.quizcafe.core.domain.usecase.solving.GradeQuizUseCase
 import com.android.quizcafe.core.domain.usecase.solving.SolveQuizBookUseCase
 import com.android.quizcafe.core.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -22,7 +25,8 @@ class QuizSolveViewModel @Inject constructor(
     private val getQuizBookLocalIdUseCase: GetQuizBookLocalIdUseCase,
     private val getQuizBookGradeUseCase: GetQuizBookGradeUseCase,
     private val gradeQuizUseCase: GradeQuizUseCase,
-    private val solveQuizBookUseCase: SolveQuizBookUseCase
+    private val solveQuizBookUseCase: SolveQuizBookUseCase,
+    private val getQuizGradeUseCase: GetQuizGradeUseCase
 ) : BaseViewModel<QuizSolveUiState, QuizSolveIntent, QuizSolveEffect>(
     initialState = QuizSolveUiState()
 ) {
@@ -68,7 +72,12 @@ class QuizSolveViewModel @Inject constructor(
             is QuizSolveIntent.GradeQuizError -> {
                 emitEffect(QuizSolveEffect.ShowErrorDialog(intent.message ?: ""))
             }
-
+            is QuizSolveIntent.SubmitPrev -> {
+                getQuizAnswer()
+            }
+            QuizSolveIntent.GradeQuizBookSuccess -> {
+                getQuizAnswer()
+            }
             else -> Unit
         }
     }
@@ -145,18 +154,36 @@ class QuizSolveViewModel @Inject constructor(
                 currentState.copy(
                     currentIndex = currentState.currentIndex - 1,
                 )
-            QuizSolveIntent.GradeQuizSuccess -> {
+             is QuizSolveIntent.GradeQuizSuccess -> {
+                 val quizGrade = intent.quizGrade
+                 if(quizGrade == null){
+                     currentState
+                 }
+                 else {
+                     currentState.copy(
+                         common = CommonState(true),
+                         subjective = currentState.subjective.copy(
+                             answer = quizGrade.userAnswer
+                         ),
+                         mcq = currentState.mcq.copy(
+                             selectedContent = quizGrade.userAnswer
+                         )
+                     )
+                 }
+             }
+            QuizSolveIntent.GradeQuizBookSuccess -> {
                 if (!currentState.isLastQuestion) {
                     currentState.copy(
                         currentIndex = currentState.currentIndex + 1,
                         common = CommonState(false),
                         subjective = currentState.subjective.copy(
                             answer = ""
-                        ) ,
+                        ),
                         mcq = currentState.mcq.copy(
                             selectedContent = ""
                         )
                     )
+
                 } else
                     currentState
             }
@@ -245,7 +272,7 @@ class QuizSolveViewModel @Inject constructor(
             ).collect {
                 when (it) {
                     is Resource.Success -> {
-                        sendIntent(QuizSolveIntent.GradeQuizSuccess)
+                        sendIntent(QuizSolveIntent.GradeQuizBookSuccess)
                         if(uiState.isLastQuestion){
                             sendIntent(QuizSolveIntent.SubmitAnswer)
                         }
@@ -287,6 +314,34 @@ class QuizSolveViewModel @Inject constructor(
 
                     is Resource.Failure -> {
                         Log.d("solveQuizBookUseCase", it.errorMessage)
+                        sendIntent(QuizSolveIntent.GradeQuizError(it.errorMessage))
+                    }
+                }
+            }
+        } else {
+            sendIntent(QuizSolveIntent.GradeQuizError("문제 발생"))
+        }
+    }
+    private suspend fun getQuizAnswer() {
+        val localId = state.value.quizBookLocalId
+        val quizId = state.value.currentQuiz?.id
+        if (localId != null && quizId != null) {
+            getQuizGradeUseCase(
+                quizBookGradeLocalId = localId,
+                quizId = quizId
+            ).collect {
+                when (it) {
+                    is Resource.Success -> {
+                        sendIntent(QuizSolveIntent.GradeQuizSuccess(it.data))
+                        Log.d("getQuizGradeUseCase", "Success")
+                    }
+
+                    is Resource.Loading -> {
+                        Log.d("getQuizGradeUseCase", "Loading")
+                    }
+
+                    is Resource.Failure -> {
+                        Log.d("getQuizGradeUseCase", it.errorMessage)
                         sendIntent(QuizSolveIntent.GradeQuizError(it.errorMessage))
                     }
                 }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solve/viewmodel/QuizSolveViewModel.kt
@@ -12,7 +12,6 @@ import com.android.quizcafe.core.domain.usecase.solving.GetQuizGradeUseCase
 import com.android.quizcafe.core.domain.usecase.solving.GradeQuizUseCase
 import com.android.quizcafe.core.domain.usecase.solving.SolveQuizBookUseCase
 import com.android.quizcafe.core.ui.base.BaseViewModel
-import com.android.quizcafe.feature.quiz.solve.component.AnswerState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -70,9 +69,19 @@ class QuizSolveViewModel @Inject constructor(
 
             QuizSolveIntent.NavigateToNextQuestion -> {
                 val currentState = state.value
-                saveQuizToLocal()
-                if (currentState.isLastQuestion) {
-                    submitQuizAnswer()
+                when {
+                    currentState.common.playMode == PlayMode.REVIEW_MODE && !currentState.review.showExplanation -> {
+                        saveQuizToLocal()
+                    }
+                    currentState.common.playMode == PlayMode.REVIEW_MODE && currentState.isLastQuestion -> {
+                        submitQuizAnswer()
+                    }
+                    else -> {
+                        saveQuizToLocal()
+                        if(currentState.isLastQuestion){
+                            submitQuizAnswer()
+                        }
+                    }
                 }
             }
 
@@ -81,8 +90,14 @@ class QuizSolveViewModel @Inject constructor(
             }
             is QuizSolveIntent.GradeQuizSuccess -> {
                 val currentState = state.value
-                if(!currentState.isLastQuestion){
-                    getQuizAnswer()
+                when {
+                    currentState.common.playMode == PlayMode.REVIEW_MODE -> {
+                        getQuizAnswer()
+                    }
+                    !currentState.isLastQuestion && currentState.common.playMode == PlayMode.DEFAULT -> {
+                        getQuizAnswer()
+                    }
+                    else -> Unit
                 }
             }
             is QuizSolveIntent.SelectAnswer,
@@ -115,9 +130,6 @@ class QuizSolveViewModel @Inject constructor(
                     mcq = currentState.mcq.copy(
                         selectedId = intent.option.id,
                         selectedContent = intent.option.text
-                    ),
-                    common = currentState.common.copy(
-                        isButtonEnabled = true
                     )
                 )
 
@@ -125,16 +137,15 @@ class QuizSolveViewModel @Inject constructor(
                 currentState.copy(
                     subjective = currentState.subjective.copy(
                         answer = intent.answer
-                    ),
-                    common = currentState.common.copy(
-                        isButtonEnabled = intent.answer.isNotBlank()
                     )
                 )
 
             is QuizSolveIntent.Initialize -> {
                 if (intent.quizBookId < 0) {
                     currentState.copy(
-                        playMode = PlayMode.REVIEW_MODE,
+                        common = currentState.common.copy(
+                            playMode = PlayMode.REVIEW_MODE
+                        ),
                         isLoading = true,
                         errorMessage = null
                     )
@@ -160,121 +171,22 @@ class QuizSolveViewModel @Inject constructor(
                 )
 
             QuizSolveIntent.NavigateToPreviousQuestion -> {
-                if (currentState.currentIndex > 0) {
-                    if (currentState.playMode == PlayMode.DEFAULT) {
-                        // DEFAULT_MODE에서는 이전 문제로 이동하고 상태 초기화
-                        // TODO: 확장함수로 분리
-                        currentState.copy(
-                            currentIndex = currentState.currentIndex - 1,
-                            common = CommonState(false),
-                            subjective = currentState.subjective.copy(
-                                answer = ""
-                            ),
-                            mcq = currentState.mcq.copy(
-                                selectedContent = ""
-                            ),
-                            review = ReviewState()
-                        )
-                    } else {
-                        currentState.copy(
-                            currentIndex = currentState.currentIndex - 1,
-                        )
-                    }
+                if (currentState.common.currentIndex > 0) {
+                    currentState.previousQuestionReset()
                 } else {
-                    // 첫 번째 문제에서는 이동하지 않음
                     currentState
                 }
             }
 
 
-            is QuizSolveIntent.GetQuizGradeSuccess -> {
-                val quizGrade = intent.quizGrade
-                if (quizGrade == null) {
-                    currentState
-                } else {
-                    when (currentState.playMode) {
-                        PlayMode.DEFAULT -> {
-                            currentState.copy(
-                                common = CommonState(true),
-                                subjective = currentState.subjective.copy(
-                                    answer = quizGrade.userAnswer
-                                ),
-                                mcq = currentState.mcq.copy(
-                                    selectedContent = quizGrade.userAnswer
-                                )
-                            )
-                        }
-
-                        PlayMode.REVIEW_MODE -> {
-                            if (currentState.review.showExplanation) {
-                                // 다음 문제 클릭했을때 reduce 로직
-                                if(currentState.currentGrade != null) {
-                                    currentState.copy(
-                                        currentGrade = null,
-                                        currentIndex = currentState.currentIndex + 1,
-                                        subjective = currentState.subjective.copy(
-                                            answer = ""
-                                        ),
-                                        mcq = currentState.mcq.copy(
-                                            selectedContent = ""
-                                        ),
-                                        review = ReviewState()
-                                    )
-                                }else{
-                                    // 이전 문제 클릭했을때 reduce 로직
-                                    currentState.copy(
-                                        currentGrade = quizGrade,
-                                        subjective = currentState.subjective.copy(
-                                            answer = quizGrade.userAnswer
-                                        ),
-                                        mcq = currentState.mcq.copy(
-                                            selectedContent = quizGrade.userAnswer
-                                        ),
-                                        review = currentState.review.copy(
-                                            answerState = if (quizGrade.isCorrect) AnswerState.CORRECT else AnswerState.INCORRECT,
-                                            showExplanation = true,
-                                            explanation = currentState.currentQuiz?.explanation ?: ""
-                                        )
-                                    )
-                                }
-                            } else {
-                                currentState.copy(
-                                    currentGrade = quizGrade,
-                                    subjective = currentState.subjective.copy(
-                                        answer = quizGrade.userAnswer,
-                                        correctAnswer = currentState.currentQuiz?.answer
-                                    ),
-                                    mcq = currentState.mcq.copy(
-                                        selectedContent = quizGrade.userAnswer,
-                                        correctContent = if(currentState.questionInfo.type == QuestionType.MULTIPLE_CHOICE)currentState.optionList[(currentState.currentQuiz?.answer ?: "0").toInt()-1].text else currentState.currentQuiz?.answer
-                                    ),
-                                    review = currentState.review.copy(
-                                        answerState = if (quizGrade.isCorrect) AnswerState.CORRECT else AnswerState.INCORRECT,
-                                        showExplanation = true,
-                                        explanation = currentState.currentQuiz?.explanation ?: ""
-                                    )
-                                )
-                            }
-                        }
-                    }
-                }
-            }
+            is QuizSolveIntent.GetQuizGradeSuccess ->
+                intent.quizGrade
+                    ?.let { currentState.applyFetchedGrade(it) }
+                    ?: currentState
 
 
             QuizSolveIntent.GradeQuizSuccess -> {
-                if (!currentState.isLastQuestion && currentState.playMode == PlayMode.DEFAULT) {
-                    currentState.copy(
-                        currentIndex = currentState.currentIndex + 1,
-                        common = CommonState(false),
-                        subjective = currentState.subjective.copy(
-                            answer = ""
-                        ),
-                        mcq = currentState.mcq.copy(
-                            selectedContent = ""
-                        )
-                    )
-                } else
-                    currentState
+                currentState.onLocalSaveSuccess()
             }
             is QuizSolveIntent.HandleError,
             QuizSolveIntent.NavigateBack,
@@ -352,7 +264,7 @@ class QuizSolveViewModel @Inject constructor(
         val uiState = state.value
         val quiz = uiState.currentQuiz
         val localId = uiState.quizBookLocalId
-        val userAnswer = when (uiState.questionInfo.type) {
+        val userAnswer = when (uiState.questionType) {
             QuestionType.SUBJECTIVE -> uiState.subjective.answer
             else -> uiState.mcq.selectedContent
         }

--- a/app/src/main/java/com/android/quizcafe/feature/quiz/solvingResult/QuizBookSolvingResultRoute.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quiz/solvingResult/QuizBookSolvingResultRoute.kt
@@ -1,6 +1,5 @@
 package com.android.quizcafe.feature.quiz.solvingResult
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
@@ -6,6 +6,7 @@ import com.android.quizcafe.core.ui.base.BaseContract
 data class QuizBookDetailUiState(
     val quizBookId: Long = 2,
     val quizBookDetail: QuizBookDetail = QuizBookDetail(),
+    val isCheckedReviewMode : Boolean,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 ) : BaseContract.UiState

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
@@ -6,7 +6,6 @@ import com.android.quizcafe.core.ui.base.BaseContract
 data class QuizBookDetailUiState(
     val quizBookId: Long = 2,
     val quizBookDetail: QuizBookDetail = QuizBookDetail(),
-    val isCheckedReviewMode : Boolean,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 ) : BaseContract.UiState

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
@@ -6,7 +6,7 @@ import com.android.quizcafe.core.ui.base.BaseContract
 data class QuizBookDetailUiState(
     val quizBookId: Long = 2,
     val quizBookDetail: QuizBookDetail = QuizBookDetail(),
-    val isReviewModeChecked : Boolean = false,
+    val isReviewModeChecked: Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 ) : BaseContract.UiState
@@ -14,7 +14,7 @@ data class QuizBookDetailUiState(
 sealed class QuizBookDetailIntent : BaseContract.ViewIntent {
     data object LoadQuizBookDetail : QuizBookDetailIntent()
     data class ClickQuizSolve(val quizBookId: Long) : QuizBookDetailIntent()
-    data class ClickReviewMode(val isChecked : Boolean) : QuizBookDetailIntent()
+    data class ClickReviewMode(val isChecked: Boolean) : QuizBookDetailIntent()
     data object ClickMarkQuizBook : QuizBookDetailIntent()
     data object ClickUnmarkQuizBook : QuizBookDetailIntent()
     data object ClickUser : QuizBookDetailIntent()

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailContract.kt
@@ -6,6 +6,7 @@ import com.android.quizcafe.core.ui.base.BaseContract
 data class QuizBookDetailUiState(
     val quizBookId: Long = 2,
     val quizBookDetail: QuizBookDetail = QuizBookDetail(),
+    val isReviewModeChecked : Boolean = false,
     val isLoading: Boolean = false,
     val errorMessage: String? = null,
 ) : BaseContract.UiState
@@ -13,6 +14,7 @@ data class QuizBookDetailUiState(
 sealed class QuizBookDetailIntent : BaseContract.ViewIntent {
     data object LoadQuizBookDetail : QuizBookDetailIntent()
     data class ClickQuizSolve(val quizBookId: Long) : QuizBookDetailIntent()
+    data class ClickReviewMode(val isChecked : Boolean) : QuizBookDetailIntent()
     data object ClickMarkQuizBook : QuizBookDetailIntent()
     data object ClickUnmarkQuizBook : QuizBookDetailIntent()
     data object ClickUser : QuizBookDetailIntent()

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailRoute.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailRoute.kt
@@ -1,6 +1,5 @@
 package com.android.quizcafe.feature.quizbookdetail
 
-import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailRoute.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailRoute.kt
@@ -1,5 +1,6 @@
 package com.android.quizcafe.feature.quizbookdetail
 
+import android.util.Log
 import android.widget.Toast
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailScreen.kt
@@ -18,6 +18,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -37,7 +42,7 @@ fun QuizBookDetailScreen(
     sendIntent: (QuizBookDetailIntent) -> Unit
 ) {
     val quizBookDetail = state.quizBookDetail
-
+    var isChecked by remember { mutableStateOf(false) }
 
     Scaffold(
         bottomBar = {

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailScreen.kt
@@ -18,10 +18,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -42,7 +38,6 @@ fun QuizBookDetailScreen(
 ) {
     val quizBookDetail = state.quizBookDetail
 
-    var isChecked by remember { mutableStateOf(false) }
 
     Scaffold(
         bottomBar = {

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailScreen.kt
@@ -18,11 +18,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -42,7 +37,6 @@ fun QuizBookDetailScreen(
     sendIntent: (QuizBookDetailIntent) -> Unit
 ) {
     val quizBookDetail = state.quizBookDetail
-    var isChecked by remember { mutableStateOf(false) }
 
     Scaffold(
         bottomBar = {
@@ -52,14 +46,14 @@ fun QuizBookDetailScreen(
             ) {
                 Row(
                     modifier = Modifier.clickable {
-                        isChecked = !isChecked
+                        sendIntent(QuizBookDetailIntent.ClickReviewMode(!state.isReviewModeChecked))
                     },
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Icon(
-                        painter = painterResource(if (isChecked) R.drawable.ic_check_circle_fill else R.drawable.ic_check_circle_unfill),
+                        painter = painterResource(if (state.isReviewModeChecked) R.drawable.ic_check_circle_fill else R.drawable.ic_check_circle_unfill),
                         contentDescription = null,
-                        tint = if (isChecked) checkedColor else MaterialTheme.colorScheme.onSurface,
+                        tint = if (state.isReviewModeChecked) checkedColor else MaterialTheme.colorScheme.onSurface,
                     )
                     Spacer(Modifier.width(4.dp))
                     Text("즉시 채점 모드")

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailViewModel.kt
@@ -21,7 +21,13 @@ class QuizBookDetailViewModel @Inject constructor(
 
     override suspend fun handleIntent(intent: QuizBookDetailIntent) {
         when (intent) {
-            is QuizBookDetailIntent.ClickQuizSolve -> emitEffect(QuizBookDetailEffect.NavigateToQuizSolve(intent.quizBookId))
+            is QuizBookDetailIntent.ClickQuizSolve -> {
+                // 한문제씩 풀기 모드면 음수로 quizBookId 전달
+                if(state.value.isReviewModeChecked)
+                    emitEffect(QuizBookDetailEffect.NavigateToQuizSolve(intent.quizBookId * -1))
+                else
+                    emitEffect(QuizBookDetailEffect.NavigateToQuizSolve(intent.quizBookId))
+            }
             QuizBookDetailIntent.ClickMarkQuizBook -> markQuizBook()
             QuizBookDetailIntent.ClickUnmarkQuizBook -> unmarkQuizBook()
             QuizBookDetailIntent.ClickUser -> emitEffect(QuizBookDetailEffect.NavigateToUserPage)
@@ -32,6 +38,7 @@ class QuizBookDetailViewModel @Inject constructor(
             is QuizBookDetailIntent.UpdateQuizBookId -> {}
             is QuizBookDetailIntent.FailGetQuizBookDetail -> emitEffect(QuizBookDetailEffect.ShowError(intent.errorMessage ?: ""))
             is QuizBookDetailIntent.FailUpdateSaveState -> emitEffect(QuizBookDetailEffect.ShowError(intent.errorMessage ?: ""))
+            is QuizBookDetailIntent.ClickReviewMode -> {}
         }
     }
 
@@ -42,7 +49,7 @@ class QuizBookDetailViewModel @Inject constructor(
             QuizBookDetailIntent.ClickMarkQuizBook -> currentState.copy(isLoading = true, errorMessage = null)
             QuizBookDetailIntent.ClickUnmarkQuizBook -> currentState.copy(isLoading = true, errorMessage = null)
             QuizBookDetailIntent.ClickUser -> currentState.copy(isLoading = true, errorMessage = null)
-
+            is QuizBookDetailIntent.ClickReviewMode -> currentState.copy(isReviewModeChecked = intent.isChecked)
             is QuizBookDetailIntent.UpdateQuizBookId -> currentState.copy(quizBookId = intent.quizBookId)
 
             is QuizBookDetailIntent.SuccessGetQuizBookDetail -> currentState.copy(

--- a/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailViewModel.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/quizbookdetail/QuizBookDetailViewModel.kt
@@ -23,10 +23,11 @@ class QuizBookDetailViewModel @Inject constructor(
         when (intent) {
             is QuizBookDetailIntent.ClickQuizSolve -> {
                 // 한문제씩 풀기 모드면 음수로 quizBookId 전달
-                if(state.value.isReviewModeChecked)
+                if (state.value.isReviewModeChecked) {
                     emitEffect(QuizBookDetailEffect.NavigateToQuizSolve(intent.quizBookId * -1))
-                else
+                } else {
                     emitEffect(QuizBookDetailEffect.NavigateToQuizSolve(intent.quizBookId))
+                }
             }
             QuizBookDetailIntent.ClickMarkQuizBook -> markQuizBook()
             QuizBookDetailIntent.ClickUnmarkQuizBook -> unmarkQuizBook()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,8 @@
     <string name="resend">재전송</string>
     <string name="quiz_topbar_title">문제 %1$d of %2$d</string>
     <string name="quiz_time_format">%1$02d:%2$02d</string>
-    <string name="solve_btn_next_text">다음 문제</string>
+    <string name="solve_btn_next_text">다음</string>
+    <string name="solve_btn_prev_text">이전</string>
     <string name="pick_category">카테고리 선택</string>
     <string name="filter">필터</string>
     <string name="quiz_book_count_description">%1$s개의 문제집이 있어요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,8 @@
     <string name="resend">재전송</string>
     <string name="quiz_topbar_title">문제 %1$d of %2$d</string>
     <string name="quiz_time_format">%1$02d:%2$02d</string>
-    <string name="solve_btn_next_text">다음 문제</string>
+    <string name="solve_btn_next_text">다음</string>
+    <string name="solve_btn_prev_text">이전</string>
     <string name="pick_category">카테고리 선택</string>
     <string name="filter">필터</string>
     <string name="quiz_book_count_description">%1$s개의 문제집이 있어요</string>


### PR DESCRIPTION
## Description

- [x] 이전 문제 버튼 로직 추가
- [x] 이전 문제로 이동시 로컬에서 저장된 기록 가져옴
- [x] 한문제씩 풀기 모드 로직 추가

---
## Summary
- 주관식 및 OX 문제에서 있던 버그를 수정하였습니다
- 이전 버튼을 추가하였습니다
- 이전 버튼시에 GetQuizGradeUseCase를 통해 로컬에 저장되어 있는 quizGradeEntity 가져와 화면에 뿌려주었습니다
- 한문제씩 풀기 모드를 구현하였습니다.

---



---
## Test
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 단위 테스트 또는 통합 테스트를 추가했습니다.
- [ ] UI 테스트를 진행했습니다.
- [ ] CI 테스트까지 완료했습니다.

---
## Related Issue Tickets
resolved #145

---
