### PR TITLE
[SQC-102] QuizBookDetail 화면 bottomNavigationBar 제거 및 route 설정

### DIFF
--- a/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
@@ -23,7 +23,6 @@ import com.android.quizcafe.feature.quizbooklist.QuizBookListRoute
 import com.android.quizcafe.main.navigation.navigatePopUpToStartDestination
 import com.android.quizcafe.main.navigation.navigateSingleTopTo
 import com.android.quizcafe.main.navigation.routes.MainRoute
-import com.android.quizcafe.main.navigation.routes.QuizSolveRoute
 import com.android.quizcafe.main.navigation.routes.UpdateRoute
 
 data class MainTab(

--- a/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
+++ b/app/src/main/java/com/android/quizcafe/feature/main/MainScreen.kt
@@ -19,12 +19,10 @@ import com.android.quizcafe.feature.categorypicker.CategoryRoute
 import com.android.quizcafe.feature.main.home.HomeRoute
 import com.android.quizcafe.feature.main.mypage.MyPageRoute
 import com.android.quizcafe.feature.main.workbook.WorkBookRoute
-import com.android.quizcafe.feature.quizbookdetail.QuizBookDetailRoute
 import com.android.quizcafe.feature.quizbooklist.QuizBookListRoute
 import com.android.quizcafe.main.navigation.navigatePopUpToStartDestination
 import com.android.quizcafe.main.navigation.navigateSingleTopTo
 import com.android.quizcafe.main.navigation.routes.MainRoute
-import com.android.quizcafe.main.navigation.routes.QuizSolveRoute
 
 data class MainTab(
     val route: String,
@@ -113,27 +111,8 @@ fun MainBottomNavHost(
 
             QuizBookListRoute(
                 category = category,
-                navigateToQuizBookDetail = { quizBookId -> bottomNavController.navigateSingleTopTo("${MainRoute.QuizBookDetail.route}/$quizBookId") },
+                navigateToQuizBookDetail = { quizBookId -> rootNavController.navigateSingleTopTo("${MainRoute.QuizBookDetail.route}/$quizBookId") },
                 navigateToCategory = {},
-            )
-        }
-        composable(
-            route = "${MainRoute.QuizBookDetail.route}/{quizBookId}",
-            arguments = listOf(
-                navArgument("quizBookId") {
-                    type = NavType.LongType
-                    nullable = false
-                    defaultValue = 0L
-                }
-            )
-        ) { backStackEntry ->
-            val quizBookId = backStackEntry.arguments?.getLong("quizBookId") ?: 0L
-
-            QuizBookDetailRoute(
-                quizBookId = quizBookId,
-                navigateToQuizBookPicker = {},
-                navigateToQuizSolve = { id -> rootNavController.navigateSingleTopTo("${QuizSolveRoute.QuizSolve.route}/$id") },
-                navigateToUserPage = {}
             )
         }
     }

--- a/app/src/main/java/com/android/quizcafe/main/navigation/QuizCafeNavHost.kt
+++ b/app/src/main/java/com/android/quizcafe/main/navigation/QuizCafeNavHost.kt
@@ -16,6 +16,7 @@ import com.android.quizcafe.feature.login.LoginRoute
 import com.android.quizcafe.feature.main.MainScreen
 import com.android.quizcafe.feature.quiz.solve.QuizSolveRoute
 import com.android.quizcafe.feature.quiz.solvingResult.QuizBookSolvingResultRoute
+import com.android.quizcafe.feature.quizbookdetail.QuizBookDetailRoute
 import com.android.quizcafe.feature.signup.SignUpRoute
 import com.android.quizcafe.main.navigation.routes.AuthRoute
 import com.android.quizcafe.main.navigation.routes.MainRoute
@@ -70,6 +71,25 @@ fun NavGraphBuilder.mainGraph(navController: NavHostController) {
         route = MainRoute.Graph.route
     ) {
         composable(MainRoute.Home.route) { MainScreen(rootNavController = navController) }
+        composable(
+            route = "${MainRoute.QuizBookDetail.route}/{quizBookId}",
+            arguments = listOf(
+                navArgument("quizBookId") {
+                    type = NavType.LongType
+                    nullable = false
+                    defaultValue = 0L
+                }
+            )
+        ) { backStackEntry ->
+            val quizBookId = backStackEntry.arguments?.getLong("quizBookId") ?: 0L
+
+            QuizBookDetailRoute(
+                quizBookId = quizBookId,
+                navigateToQuizBookPicker = {},
+                navigateToQuizSolve = { id -> navController.navigateSingleTopTo("${QuizSolveRoute.QuizSolve.route}/$id") },
+                navigateToUserPage = {}
+            )
+        }
         quizSolveGraph(navController)
     }
 }


### PR DESCRIPTION
## Description
- QuizBookDetail 화면에서 BottomNavigationBar를 제거했습니다.
- 기존에 MainScreen의 Scaffold 내부에 포함되어 있던 QuizBookDetail 관련 코드를 분리하여, MainGraph에서 별도 composable로 관리하도록 변경했습니다.
- 이로 인해 QuizBookListRoute에서 QuizBookDetail로 이동 시 route 문제(등록되지 않은 경로)가 발생하여, 네비게이션 컨트롤러를 rootNavController로 변경하였습니다.
---
## Summary

---
### ScreenShot
<img src="https://github.com/user-attachments/assets/587a21ba-77fa-4bee-a5a8-a1bd4d56ca6c" width="400"/>

---
## Test
- [ ] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 단위 테스트 또는 통합 테스트를 추가했습니다.
- [ ] UI 테스트를 진행했습니다.
- [ ] CI 테스트까지 완료했습니다.

---
## Related Issue Tickets
resolved #

---
